### PR TITLE
Print out Transformer model variables 

### DIFF
--- a/translation/tensorflow/transformer/model/transformer.py
+++ b/translation/tensorflow/transformer/model/transformer.py
@@ -23,6 +23,7 @@ from __future__ import division
 from __future__ import print_function
 
 import tensorflow as tf
+import numpy as np
 
 from model import attention_layer
 from model import beam_search
@@ -242,6 +243,22 @@ class Transformer(object):
     top_scores = scores[:, 0]
 
     return {"outputs": top_decoded_ids, "scores": top_scores}
+
+  def log_variable_sizes(self):
+    """Print variable names, sizes, and shapes."""
+    var_list = tf.trainable_variables()
+    name_to_var = {v.name: v for v in var_list}
+
+    total_size = 0
+    print("{:<15}{:<15}{:<80}".format(
+        "Size", "Shape", "Variable (sorted by name)"))
+    for v_name in sorted(list(name_to_var)):
+      v = name_to_var[v_name]
+      v_size = int(np.prod(np.array(v.shape.as_list())))
+      print("{:<15}{:<15}{:<80}".format(v_size, str(v.shape), v_name))
+      total_size += v_size
+
+    print("Total number of parameters: %s" % total_size)
 
 
 class LayerNormalization(tf.layers.Layer):

--- a/translation/tensorflow/transformer/transformer_main.py
+++ b/translation/tensorflow/transformer/transformer_main.py
@@ -53,6 +53,11 @@ def model_fn(features, labels, mode, params):
 
     output = model(inputs, targets)
 
+    # Log all variables once.
+    if not getattr(params, "logged_variables", False):
+      model.log_variable_sizes()
+      params.logged_variables = True
+
     # When in prediction mode, the labels/targets is None. The model output
     # is the prediction
     if mode == tf.estimator.ModeKeys.PREDICT:


### PR DESCRIPTION
@bitfort @David-Levinthal

Here's some code that prints out all of the transformer model variables. Outputs something like this:

```
Size           Shape          Variable (sorted by name)                                                       
1048576        (1024, 1024)   model/Transformer/decoder_stack/layer_0/encdec_attention/attention/k/kernel:0   
1048576        (1024, 1024)   model/Transformer/decoder_stack/layer_0/encdec_attention/attention/output_transform/kernel:0
1048576        (1024, 1024)   model/Transformer/decoder_stack/layer_0/encdec_attention/attention/q/kernel:0   
1048576        (1024, 1024)   model/Transformer/decoder_stack/layer_0/encdec_attention/attention/v/kernel:0   
1024           (1024,)        model/Transformer/decoder_stack/layer_0/encdec_attention/layer_normalization/layer_norm_bias:0
1024           (1024,)        model/Transformer/decoder_stack/layer_0/encdec_attention/layer_normalization/layer_norm_scale:0
4096           (4096,)        model/Transformer/decoder_stack/layer_0/ffn/feed_foward_network/filter_layer/bias:0
4194304        (1024, 4096)   model/Transformer/decoder_stack/layer_0/ffn/feed_foward_network/filter_layer/kernel:0
1024           (1024,)        model/Transformer/decoder_stack/layer_0/ffn/feed_foward_network/output_layer/bias:0
4194304        (4096, 1024)   model/Transformer/decoder_stack/layer_0/ffn/feed_foward_network/output_layer/kernel:0
1024           (1024,)        model/Transformer/decoder_stack/layer_0/ffn/layer_normalization/layer_norm_bias:0
... [edited out]
Total number of parameters: 210804736
```