### PR TITLE
Transformer multi GPU 

### DIFF
--- a/translation/tensorflow/transformer/model/model_params.py
+++ b/translation/tensorflow/transformer/model/model_params.py
@@ -57,3 +57,14 @@ class TransformerBigParams(TransformerBaseParams):
   hidden_size = 1024
   filter_size = 4096
   num_heads = 16
+
+
+class TransformerBaseMultiGPUParams(TransformerBaseParams):
+  """Parameters for running the base model with multiple GPUS."""
+  learning_rate_warmup_steps = 8000
+
+
+class TransformerBigMultiGPUParams(TransformerBigParams):
+  """Parameters for running the big model with multiple GPUS."""
+  learning_rate_warmup_steps = 8000
+  layer_postprocess_dropout = 0.3

--- a/translation/tensorflow/transformer/transformer_main.py
+++ b/translation/tensorflow/transformer/transformer_main.py
@@ -276,8 +276,8 @@ def get_num_gpus(n):
   total_gpus = sum([1 for d in local_device_protos if d.device_type == "GPU"])
 
   if n > total_gpus:
-    raise ValueError("Number of GPUs specified by flag --num_gpu is greater "
-                     "than the number of GPUs detected.\n\t--num_gpu: %d, "
+    raise ValueError("Number of GPUs specified by flag --num_gpus is greater "
+                     "than the number of GPUs detected.\n\t--num_gpus: %d, "
                      "gpus detected: %d" % (n, total_gpus))
   elif n == -1:
     return total_gpus
@@ -290,8 +290,8 @@ def main(_):
   # estimator)
   tf.logging.set_verbosity(tf.logging.INFO)
 
-  num_gpus = get_num_gpus(FLAGS.num_gpu)
-  print("Using %d gpus." % num_gpus)
+  num_gpus = get_num_gpus(FLAGS.num_gpus)
+  print("Using %d gpus" % num_gpus)
 
   if FLAGS.params == "base" and num_gpus <= 1:
     params = model_params.TransformerBaseParams
@@ -339,7 +339,8 @@ def main(_):
   if num_gpus > 1:
     if FLAGS.batch_type == "global":
       params.batch_size = int(params.batch_size / num_gpus)
-    print("Using batch size %d." % params.batch_size)
+    print("Using per-device batch size = %d, global batch size = %d"
+          % (params.batch_size, params.batch_size * num_gpus))
     if FLAGS.all_reduce_alg:
       dist_strat = tf.contrib.distribute.MirroredStrategy(
         num_gpus=num_gpus,
@@ -432,7 +433,7 @@ if __name__ == "__main__":
 
   # Multi GPU arguments
   parser.add_argument(
-      "--num_gpu", "-ng", type=int, default=None,
+      "--num_gpus", "-ng", type=int, default=None,
       help="How many GPUs to use with the DistributionStrategies API. Must be "
            "an int between [-1, # of GPUs detected by TensorFlow]. If -1, then "
            "all of the GPUs are used. If left as None, then the model will run "
@@ -444,7 +445,7 @@ if __name__ == "__main__":
       help="Defines the batch size given to each device when running with "
            "multiple GPUs. \"per_device\" indicates that each device should "
            "get batches with size batch_size. \"global\" indicates that each "
-           "device should get batches with size batch_size/num_gpu.",
+           "device should get batches with size batch_size/num_gpus.",
       metavar="<btype>")
   parser.add_argument(
       "--batch_size", type=int, default=None,


### PR DESCRIPTION
Added option to run Transformer with multiple GPUs. If none of the flags below are set, the Transformer will run with a single GPU.

Flags:
* `num_gpu`
* `batch_type` - specifies whether the batch size should be treated as global or per-device.
* `batch_size` - defaults to use the batch size defined in model_params.py
* `all_reduce_alg` - change the algorithm used to perform all-reduce. **`hierarchical_copy`** appears to work best for transformer.

Tested with 4 GPUs: (Results are about the same as a single-gpu run)
```
# Train for 10 epochs
python transformer_main.py --data_dir $DATA_DIR --model_dir $MODEL_DIR --num_gpu=4 \
  --all_reduce_alg=hierarchical_copy --random_seed 1

# Download and translate test data
sacrebleu -t wmt14 -l en-de  
python translate.py --file ~/.sacrebleu/wmt14/en-de.en --file_out output.de \
  --data_dir $DATA_DIR --model_dir $MODEL_DIR

cat output.de | sacrebleu ~/.sacrebleu/wmt14/en-de.de
# Output (case-sensitive score): 25.79

cat output.de | sacrebleu -tok intl ~/.sacrebleu/wmt14/en-de.de
# Output (case-sensitive score with tokenization): 26.57

cat output.de | sacrebleu -tok intl -lc ~/.sacrebleu/wmt14/en-de.de
# Output (case-insensitive score with tokenization): 27.08
```

Each epoch takes ~3.5hr to run, instead of the single-gpu 10 hours. 
