### PR TITLE
Don't make log_deferred counter variable trainable

### DIFF
--- a/compliance/mlperf_compliance/tf_mlperf_log.py
+++ b/compliance/mlperf_compliance/tf_mlperf_log.py
@@ -51,7 +51,7 @@ def log_deferred(op, log_id, every_n=1, first_n=None):
   if not first_n is not None and first_n == 1:
     return tf.Print(op, [tf.timestamp(), op], message=prefix, first_n=1)
 
-  counter = tf.Variable(tf.zeros(shape=(), dtype=tf.int32) - 1)
+  counter = tf.Variable(tf.zeros(shape=(), dtype=tf.int32) - 1, trainable=False)
   increment = tf.assign_add(counter, 1, use_locking=True)
   return tf.cond(
       tf.equal(tf.mod(increment, every_n), 0),


### PR DESCRIPTION
This fixes fp16 support on the [TensorFlow reference image classification model](https://github.com/mlperf/training/tree/master/image_classification/tensorflow). Before, when the counter variable was trainable, a gradient for the counter would be generated. The gradient would be None since the counter did not affect the loss. When the gradient was divided by the loss scale, the following error would occur:

```
TypeError: unsupported operand type(s) for /: 'NoneType' and 'int'
```