### PR TITLE
Replacing broken link

### DIFF
--- a/object_detection/download_dataset.sh
+++ b/object_detection/download_dataset.sh
@@ -1,4 +1,4 @@
-wget https://s3-us-west-2.amazonaws.com/detectron/coco/coco_annotations_minival.tgz
+wget https://dl.fbaipublicfiles.com/detectron/coco/coco_annotations_minival.tgz
 wget http://images.cocodataset.org/zips/train2014.zip
 wget http://images.cocodataset.org/zips/val2014.zip
 wget http://images.cocodataset.org/annotations/annotations_trainval2014.zip


### PR DESCRIPTION
The AWS S3 bucket containing coco_annotations_minival.tgz is no longer accessible.  Replacing with confirmed working link.