### PR TITLE
Repairing directory generation step

### DIFF
--- a/object_detection/caffe2/extract_dataset.sh
+++ b/object_detection/caffe2/extract_dataset.sh
@@ -1,4 +1,4 @@
-mkdir detectron/lib/datasets/data/coco
+mkdir -p detectron/lib/datasets/data/coco
 mv coco_annotations_minival.tgz detectron/lib/datasets/data/coco
 mv train2014.zip detectron/lib/datasets/data/coco
 mv val2014.zip detectron/lib/datasets/data/coco


### PR DESCRIPTION
'mkdir' cannot generate the nested path and causes an error when running the script.  Replacing with 'mkdir -p'.