### PR TITLE
Update mlperf_compliance for v0.6 logging requirements

### DIFF
--- a/compliance/README.md
+++ b/compliance/README.md
@@ -1,1 +1,41 @@
 # MLPerf Compliance Logging Utilities and Helper Functions
+
+## Install
+
+For development, you may download the latest version and install from local path:
+
+```sh
+git clone https://github.com/mlperf/training.git
+pip install training/compliance
+```
+
+For submission, you may want to use a versioned package for sake of reproducibility. Here are some possible ways to do it:
+
+- Install from github using a given commit (Replace COMMIT_HASH below with actual commit hash, the double quotes are needed):
+  ```
+  pip install "git+https://github.com/mlperf/training@COMMIT_HASH#subdirectory=compliance"
+  ```
+- Or, install from pypi iff a known compatible version is available (The version used must be known as compatible with current mlperf version. Replace VERSION below with the actual version number):
+  ```
+  pip install mlperf_compliance==VERSION
+  ```
+
+Uninstall:
+
+```sh
+pip uninstall mlperf_compliance
+```
+
+## Use
+
+By default, the logs are written to stdout. To log to a file, set environment variable `COMPLIANCE_FILE` in your run environment, e.g.:
+
+```sh
+export COMPLIANCE_FILE=/your/result/file.log
+```
+
+[Here](mlperf_compliance/examples/dummy_example.py) is an example of how to use the package in benchmark codes. You can run the example by:
+
+```sh
+python3 -m mlperf_compliance.examples.dummy_example 
+```

--- a/compliance/mlperf_compliance/constant_sets.py
+++ b/compliance/mlperf_compliance/constant_sets.py
@@ -1,0 +1,124 @@
+# Copyright 2019 MLBenchmark Group. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from mlperf_compliance import constants
+
+BENCHMARK_NAME_SET = set([
+  constants.RESNET,
+  constants.SSD,
+  constants.MASKRCNN,
+  constants.GNMT,
+  constants.TRANSFORMER,
+  constants.MINIGO
+])
+
+COMMON_KEY_SET = set([
+  constants.SUBMISSION_ORG,
+  constants.SUBMISSION_PLATFORM,
+  constants.SUBMISSION_STATUS,
+  constants.SUBMISSION_BENCHMARK,
+  constants.SUBMISSION_POC_NAME,
+  constants.SUBMISSION_POC_EMAIL,
+  constants.SUBMISSION_ENTRY,
+
+  constants.BLOCK_START,
+  constants.BLOCK_STOP,
+  constants.EPOCH_START,
+  constants.EPOCH_STOP,
+  constants.EVAL_START,
+  constants.EVAL_STOP,
+  constants.INIT_START,
+  constants.INIT_STOP,
+  constants.RUN_START,
+  constants.RUN_STOP,
+  constants.CACHE_CLEAR,
+  constants.EVAL_ACCURACY
+])
+
+STDOUT_KEY_SET = set([
+  constants.BLOCK_START,
+  constants.BLOCK_STOP,
+  constants.EPOCH_START,
+  constants.EPOCH_STOP,
+  constants.EVAL_START,
+  constants.EVAL_STOP,
+  constants.INIT_START,
+  constants.INIT_STOP,
+  constants.RUN_START,
+  constants.RUN_STOP,
+  constants.CACHE_CLEAR,
+  constants.EVAL_ACCURACY
+])
+
+RESNET_KEY_SET = set.union(COMMON_KEY_SET, set([
+  constants.GLOBAL_BATCH_SIZE,
+  constants.OPT_NAME,
+  constants.OPT_BASE_LR,
+  constants.OPT_LR_WARMUP_EPOCHS,
+  constants.OPT_LR_DECAY_BOUNDARY_EPOCHS,
+  constants.LARS_OPT_END_LR,
+  constants.LARS_OPT_LR_DECAY_STEPS,
+  constants.LARS_OPT_LR_DECAY_POLY_POWER,
+  constants.LARS_EPSILON,
+  constants.MODEL_BN_SPAN
+]))
+
+SSD_KEY_SET = set.union(COMMON_KEY_SET, set([
+  constants.GLOBAL_BATCH_SIZE,
+  constants.OPT_BASE_LR,
+  constants.OPT_WEIGHT_DECAY,
+  constants.OPT_LR_WARMUP_STEPS,
+  constants.OPT_LR_WARMUP_FACTOR,
+  constants.MAX_SAMPLES,
+  constants.MODEL_BN_SPAN
+]))
+
+MASKRCNN_KEY_SET = set.union(COMMON_KEY_SET, set([
+  constants.GLOBAL_BATCH_SIZE,
+  constants.OPT_BASE_LR,
+  constants.OPT_LR_WARMUP_STEPS,
+  constants.OPT_LR_WARMUP_FACTOR,
+  constants.NUM_IMAGE_CANDIDATES
+]))
+
+GNMT_KEY_SET = set.union(COMMON_KEY_SET, set([
+  constants.GLOBAL_BATCH_SIZE,
+  constants.OPT_LR_ALT_DECAY_FUNC,
+  constants.OPT_BASE_LR,
+  constants.OPT_LR_DECAY_INTERVAL,
+  constants.OPT_LR_DECAY_FACTOR,
+  constants.OPT_LR_DECAY_STEPS,
+  constants.OPT_LR_REMAIN_STEPS,
+  constants.OPT_LR_ALT_WARMUP_FUNC,
+  constants.OPT_LR_WARMUP_STEPS,
+  constants.MAX_SEQUENCE_LENGTH
+]))
+
+TRANSFORMER_KEY_SET = set.union(COMMON_KEY_SET, set([
+  constants.GLOBAL_BATCH_SIZE,
+  constants.OPT_NAME,
+  constants.OPT_BASE_LR,
+  constants.OPT_LR_WARMUP_STEPS,
+  constants.MAX_SEQUENCE_LENGTH,
+  constants.OPT_ADAM_BETA_1,
+  constants.OPT_ADAM_BETA_2,
+  constants.OPT_ADAM_EPSILON
+]))
+
+MINIGO_KEY_SET = set.union(COMMON_KEY_SET, set([
+  constants.GLOBAL_BATCH_SIZE,
+  constants.OPT_BASE_LR,
+  constants.OPT_LR_DECAY_BOUNDARY_STEPS
+]))

--- a/compliance/mlperf_compliance/constant_sets.py
+++ b/compliance/mlperf_compliance/constant_sets.py
@@ -32,6 +32,7 @@ COMMON_KEY_SET = set([
   constants.SUBMISSION_POC_NAME,
   constants.SUBMISSION_POC_EMAIL,
   constants.SUBMISSION_ENTRY,
+  constants.SUBMISSION_DIVISION,
 
   constants.BLOCK_START,
   constants.BLOCK_STOP,

--- a/compliance/mlperf_compliance/constants.py
+++ b/compliance/mlperf_compliance/constants.py
@@ -1,0 +1,89 @@
+# Copyright 2019 MLBenchmark Group. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Master list of constants in MLPerf log
+"""
+
+# NOTE: Keep string values in alphabetical order under each section.
+
+# Constant values - benchmark name
+GNMT = "gnmt"
+MASKRCNN = "maskrcnn"
+MINIGO = "minigo"
+NCF = "ncf"
+RESNET = "resnet"
+SSD = "ssd"
+TRANSFORMER = "transformer"
+
+# Constant values - model info
+ADAM = "adam"
+LARS = "lars"
+LAZY_ADAM = "lazy_adam"
+SGD = "sgd"
+
+# Log keys - submission info
+SUBMISSION_BENCHMARK = "submission_benchmark"
+SUBMISSION_DIVISION = "submission_division"
+SUBMISSION_ENTRY = "submission_entry"
+SUBMISSION_ORG = "submission_org"
+SUBMISSION_PLATFORM = "submission_platform"
+SUBMISSION_POC_NAME = "submission_poc_name"
+SUBMISSION_POC_EMAIL = "submission_poc_email"
+SUBMISSION_STATUS = "submission_status"
+
+# Log keys - timing info
+BLOCK_START = "block_start"
+BLOCK_STOP = "block_stop"
+EPOCH_START = "epoch_start"
+EPOCH_STOP = "epoch_stop"
+EVAL_START = "eval_start"
+EVAL_STOP = "eval_stop"
+INIT_START = "init_start"
+INIT_STOP = "init_stop"
+RUN_START = "run_start"
+RUN_STOP = "run_stop"
+
+# Log keys - common run info
+CACHE_CLEAR = "cache_clear"
+EVAL_ACCURACY = "eval_accuracy"
+
+# Log kyes - model hyperparameters
+GLOBAL_BATCH_SIZE = "global_batch_size"
+LARS_EPSILON = "lars_epsilon"
+LARS_OPT_END_LR = "lars_opt_end_learning_rate"
+LARS_OPT_LR_DECAY_POLY_POWER = "lars_opt_learning_rate_decay_poly_power"
+LARS_OPT_LR_DECAY_STEPS = "lars_opt_learning_rate_decay_steps"
+LARS_OPT_WEIGHT_DECAY = "lars_opt_weight_decay"
+MAX_SAMPLES = "max_samples"
+MAX_SEQUENCE_LENGTH = "max_sequence_length"
+MODEL_BN_SPAN = "model_bn_span"
+NUM_IMAGE_CANDIDATES = "num_image_candidates"
+OPT_ADAM_BETA_1 = "opt_adam_beta_1"
+OPT_ADAM_BETA_2 = "opt_adam_beta_2"
+OPT_ADAM_EPSILON = "opt_adam_epsilon"
+OPT_NAME = "opt_name"
+OPT_BASE_LR = "opt_base_learning_rate"
+OPT_LR_ALT_DECAY_FUNC = "opt_learning_rate_alt_decay_func"
+OPT_LR_ALT_WARMUP_FUNC = "opt_learning_rate_alt_warmup_func"
+OPT_LR_DECAY_BOUNDARY_EPOCHS = "opt_learning_rate_decay_boundary_epochs"
+OPT_LR_DECAY_BOUNDARY_STEPS = "opt_learning_rate_decay_boundary_steps"
+OPT_LR_DECAY_FACTOR = "opt_learning_rate_decay_factor"
+OPT_LR_DECAY_INTERVAL = "opt_learning_rate_decay_interval"
+OPT_LR_DECAY_STEPS = "opt_learning_rate_decay_steps"
+OPT_LR_REMAIN_STEPS = "opt_learning_rate_remain_steps"
+OPT_LR_WARMUP_EPOCHS = "opt_learning_rate_warmup_epochs"
+OPT_LR_WARMUP_FACTOR = "opt_learning_rate_warmup_factor"
+OPT_LR_WARMUP_STEPS = "opt_learning_rate_warmup_steps"
+OPT_WEIGHT_DECAY = "opt_weight_decay"

--- a/compliance/mlperf_compliance/examples/dummy_example.py
+++ b/compliance/mlperf_compliance/examples/dummy_example.py
@@ -1,0 +1,66 @@
+# Copyright 2019 MLBenchmark Group. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import os
+
+from mlperf_compliance import constants
+from mlperf_compliance import mlperf_log
+
+def run_example_logs():
+  """Example usage of mlperf_compliance."""
+
+  # Find root dir of the benchmark, this is for this example only,
+  # you may apply a different approach to find root dir.
+  root_dir = os.path.normpath(
+      os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", ".."))
+
+  # Set default variables, the default variables will be applied to all logs.
+  # You can try changing some of the default values and see their effects.
+  # The following information can be set:
+  #   benchmark: benchmark name, this is mainly used for model-specific
+  #       validations, not setting benchmark name will not cause errors.
+  #   root_dir: the root directory of benchmark, used for printing file paths.
+  #   stack_offset: (default=1) increase the value to go deeper into the stack
+  #       to find the callsite. For example, if this is being called by a
+  #       wraper/helper you may want to set stack_offset=1 to use the callsite
+  #       of the wraper/helper itself.
+  #   extra_print: (default=False) print a blank line before logging to clear
+  #       any text in the line.
+  #   prefix: (default="") string with which to prefix the log message. Useful
+  #       for differentiating raw lines if stitching will be required.
+  mlperf_log.setdefault(
+      benchmark="resnet",
+      root_dir=root_dir,
+      stack_offset=1,
+      extra_print=False,
+      prefix="")
+
+  # These logs will print as expected
+  mlperf_log.mlperf_print(constants.RUN_START)
+  mlperf_log.mlperf_print(constants.EVAL_ACCURACY, value=0.99)
+  mlperf_log.mlperf_print(
+          constants.EPOCH_STOP, metadata={"first_epoch_num": 1})
+  
+  # These logs may cause a warning message.
+  # The warnings are for reference only, they might not be up-to-date with
+  # the latest logging policy, and might not cover all requirements.
+  # Currently, only keys are checked against known key list if benchmark
+  # name is set. If you intend to log a new key that is not known in the
+  # policy doc, please ignore the warning.
+  mlperf_log.mlperf_print("unknown_key")
+
+
+if __name__ == "__main__":
+  run_example_logs()

--- a/compliance/mlperf_compliance/mlperf_log.py
+++ b/compliance/mlperf_compliance/mlperf_log.py
@@ -29,21 +29,18 @@ import time
 import uuid
 
 from mlperf_compliance.tags import *
+from mlperf_compliance import constant_sets
+from mlperf_compliance import validations
 
-ROOT_DIR_GNMT = None
-ROOT_DIR_MASKRCNN = None
-ROOT_DIR_MINIGO = None
-ROOT_DIR_NCF = None
+# Default global variables can be set through setdefault()
+BENCHMARK_ROOT_DIR = None
+BENCHMARK_NAME = None
+STACK_OFFSET = 1
+LOG_LINE_EXTRA_PRINT = False
+LOG_LINE_PREFIX = ""
 
-# Set by imagenet_main.py
-ROOT_DIR_RESNET = None
-
-ROOT_DIR_SSD = None
-
-# Set by transformer_main.py and process_data.py
-ROOT_DIR_TRANSFORMER = None
-
-
+# Constants
+LOG_LINE_FORMAT = "{prefix}:::MLL {timestamp:.3f} {key}: {log_json}"
 PATTERN = re.compile('[a-zA-Z0-9]+')
 
 LOG_FILE = os.getenv("COMPLIANCE_FILE")
@@ -62,25 +59,125 @@ if LOG_FILE:
 else:
   _STREAM_HANDLER.setLevel(logging.DEBUG)
 
+def setdefault(root_dir=None, benchmark=None, stack_offset=1,
+               extra_print=False, prefix=""):
+  """Set default attributes of mlperf logger"""
+  global BENCHMARK_NAME
+  global BENCHMARK_ROOT_DIR
+  global STACK_OFFSET
+  global LOG_LINE_EXTRA_PRINT
+  global LOG_LINE_PREFIX
 
+  if (benchmark is not None) and (
+      benchmark not in constant_sets.BENCHMARK_NAME_SET):
+    LOGGER.warning(
+        "WARNING: \"{}\" is not in known benchmark names.".format(benchmark))
+
+  BENCHMARK_NAME = benchmark
+  BENCHMARK_ROOT_DIR = root_dir
+  STACK_OFFSET = stack_offset
+  LOG_LINE_EXTRA_PRINT = extra_print
+  LOG_LINE_PREFIX = prefix
 
 def get_caller(stack_index=2, root_dir=None):
-  ''' Returns file.py:lineno of your caller. A stack_index of 2 will provide
-      the caller of the function calling this function. Notice that stack_index
-      of 2 or more will fail if called from global scope. '''
+  """Get caller's file and line number information.
+
+  Arguments:
+    stack_index: A stack_index of 2 will provide the caller of the
+      function calling this function. Notice that stack_index of 2
+      or more will fail if called from global scope.
+    root_dir: The root dir to prefixed to the file name.
+
+  Returns:
+    Callsite info in a dictionary with these fields:
+      "file": (string) file path
+      "lineno": (int) line number
+  """
   caller = inspect.getframeinfo(inspect.stack()[stack_index][0])
 
   # Trim the filenames for readability.
   filename = caller.filename
   if root_dir is not None:
     filename = re.sub("^" + root_dir + "/", "", filename)
-  return "%s:%d" % (filename, caller.lineno)
+  return {"file": filename, "lineno": caller.lineno}
 
 
-def _mlperf_print(key, value=None, benchmark=None, stack_offset=0,
+def mlperf_print(
+    key,
+    value=None,
+    metadata=None,
+    deferred=False,
+    benchmark=None,
+    stack_offset=None,
+    root_dir=None,
+    extra_print=None,
+    prefix=None):
+  """Print out an MLPerf log line.
+
+  Arguments:
+    key: The MLPerf log key such as 'RUN_START' or 'EVAL_ACCURACY'. See the
+      list of log keys in the spec.
+    value: The value corresponding to the log key.
+    metadata: The metadata corresponding to the log key.
+    benchmark: The short code for the benchmark being run, see the MLPerf log spec.
+    stack_offset: Increase the value to go deeper into the stack to find the
+      callsite. For example, if this is being called by a wraper/helper you
+      may want to set stack_offset=1 to use the callsite of the wraper/helper itself.
+    deferred: The value is not presently known. In that case, a unique ID will
+      be assigned as the value of this call and will be returned. The caller
+      can then include said unique ID when the value is known later.
+    root_dir: Directory prefix which will be trimmed when reporting calling
+      file for compliance logging.
+    extra_print: Print a blank line before logging to clear any text in the line.
+    prefix: String with which to prefix the log message. Useful for
+      differentiating raw lines if stitching will be required.
+
+  Example output:
+    :::MLL 1556733699.710 run_start: {"value": null, "metadata": {"lineno": 77, "file": "main.py"}}
+  """
+
+  # Get values from default attributes
+  # the default attributes can be set by calling setdefault()
+  benchmark = BENCHMARK_NAME if benchmark is None else benchmark
+  stack_offset = STACK_OFFSET if stack_offset is None else stack_offset
+  root_dir = BENCHMARK_ROOT_DIR if root_dir is None else root_dir
+  extra_print = LOG_LINE_EXTRA_PRINT if extra_print is None else extra_print
+  prefix = LOG_LINE_PREFIX if prefix is None else prefix
+
+  return_value = None
+
+  try:
+    validations.validate(key, value, metadata, benchmark)
+  except ValueError as e:
+    LOGGER.warning("WARNING: Log validation: {}".format(e))
+
+  log_meta = {}
+  if metadata and isinstance(metadata, dict):
+    log_meta.update(metadata)
+  log_meta.update(get_caller(2 + stack_offset, root_dir=root_dir))
+  log_json = json.dumps({"value": value, "metadata": log_meta})
+
+  message = LOG_LINE_FORMAT.format(
+      prefix=prefix, timestamp=time.time(), key=key, log_json=log_json)
+
+  _do_print(key, message, extra_print)
+
+  return return_value
+
+def _do_print(key, message, extra_print=False):
+  if extra_print:
+    print() # There could be prior text on a line
+  if key in constant_sets.STDOUT_KEY_SET:
+    LOGGER.info(message)
+  else:
+    LOGGER.debug(message)
+
+def _mlperf_print_v0_5(key, value=None, benchmark=None, stack_offset=0,
                   tag_set=None, deferred=False, root_dir=None,
                   extra_print=False, prefix=""):
   ''' Prints out an MLPerf Log Line.
+
+  DEPRECATED: No longer applicable to v0.6
 
   key: The MLPerf log key such as 'CLOCK' or 'QUALITY'. See the list of log keys in the spec.
   value: The value which contains no newlines.
@@ -140,7 +237,8 @@ def _mlperf_print(key, value=None, benchmark=None, stack_offset=0,
 
 GNMT_TAG_SET = set(GNMT_TAGS)
 def gnmt_print(key, value=None, stack_offset=1, deferred=False, prefix=""):
-  return _mlperf_print(key=key, value=value, benchmark=GNMT,
+  """DEPRECATED: No longer applicable to v0.6"""
+  return _mlperf_print_v0_5(key=key, value=value, benchmark=GNMT,
                        stack_offset=stack_offset, tag_set=GNMT_TAG_SET,
                        deferred=deferred, root_dir=ROOT_DIR_GNMT)
 
@@ -148,7 +246,8 @@ def gnmt_print(key, value=None, stack_offset=1, deferred=False, prefix=""):
 MASKRCNN_TAG_SET = set(MASKRCNN_TAGS)
 def maskrcnn_print(key, value=None, stack_offset=1, deferred=False,
     extra_print=True, prefix=""):
-  return _mlperf_print(key=key, value=value, benchmark=MASKRCNN,
+  """DEPRECATED: No longer applicable to v0.6"""
+  return _mlperf_print_v0_5(key=key, value=value, benchmark=MASKRCNN,
                        stack_offset=stack_offset, tag_set=MASKRCNN_TAG_SET,
                        deferred=deferred, extra_print=extra_print,
                        root_dir=ROOT_DIR_MASKRCNN, prefix=prefix)
@@ -156,7 +255,8 @@ def maskrcnn_print(key, value=None, stack_offset=1, deferred=False,
 
 MINIGO_TAG_SET = set(MINIGO_TAGS)
 def minigo_print(key, value=None, stack_offset=1, deferred=False, prefix=""):
-  return _mlperf_print(key=key, value=value, benchmark=MINIGO,
+  """DEPRECATED: No longer applicable to v0.6"""
+  return _mlperf_print_v0_5(key=key, value=value, benchmark=MINIGO,
                        stack_offset=stack_offset, tag_set=MINIGO_TAG_SET,
                        deferred=deferred, root_dir=ROOT_DIR_MINIGO,
                        prefix=prefix)
@@ -165,8 +265,9 @@ def minigo_print(key, value=None, stack_offset=1, deferred=False, prefix=""):
 NCF_TAG_SET = set(NCF_TAGS)
 def ncf_print(key, value=None, stack_offset=1, deferred=False,
               extra_print=True, prefix=""):
+  """DEPRECATED: No longer applicable to v0.6"""
   # Extra print is needed for the reference NCF because of tqdm.
-  return _mlperf_print(key=key, value=value, benchmark=NCF,
+  return _mlperf_print_v0_5(key=key, value=value, benchmark=NCF,
                        stack_offset=stack_offset, tag_set=NCF_TAG_SET,
                        deferred=deferred, extra_print=extra_print,
                        root_dir=ROOT_DIR_NCF, prefix=prefix)
@@ -174,7 +275,8 @@ def ncf_print(key, value=None, stack_offset=1, deferred=False,
 
 RESNET_TAG_SET = set(RESNET_TAGS)
 def resnet_print(key, value=None, stack_offset=1, deferred=False, prefix=""):
-  return _mlperf_print(key=key, value=value, benchmark=RESNET,
+  """DEPRECATED: No longer applicable to v0.6"""
+  return _mlperf_print_v0_5(key=key, value=value, benchmark=RESNET,
                        stack_offset=stack_offset, tag_set=RESNET_TAG_SET,
                        deferred=deferred, root_dir=ROOT_DIR_RESNET,
                        prefix=prefix)
@@ -183,7 +285,8 @@ def resnet_print(key, value=None, stack_offset=1, deferred=False, prefix=""):
 SSD_TAG_SET = set(SSD_TAGS)
 def ssd_print(key, value=None, stack_offset=1, deferred=False,
               extra_print=True, prefix=""):
-  return _mlperf_print(key=key, value=value, benchmark=SSD,
+  """DEPRECATED: No longer applicable to v0.6"""
+  return _mlperf_print_v0_5(key=key, value=value, benchmark=SSD,
                        stack_offset=stack_offset, tag_set=SSD_TAG_SET,
                        deferred=deferred, extra_print=extra_print,
                        root_dir=ROOT_DIR_SSD, prefix=prefix)
@@ -191,7 +294,8 @@ def ssd_print(key, value=None, stack_offset=1, deferred=False,
 
 TRANSFORMER_TAG_SET = set(TRANSFORMER_TAGS)
 def transformer_print(key, value=None, stack_offset=1, deferred=False, prefix=""):
-  return _mlperf_print(key=key, value=value, benchmark=TRANSFORMER,
+  """DEPRECATED: No longer applicable to v0.6"""
+  return _mlperf_print_v0_5(key=key, value=value, benchmark=TRANSFORMER,
                        stack_offset=stack_offset, tag_set=TRANSFORMER_TAG_SET,
                        deferred=deferred, root_dir=ROOT_DIR_TRANSFORMER,
                        prefix=prefix)

--- a/compliance/mlperf_compliance/tests/test_mlperf_log.py
+++ b/compliance/mlperf_compliance/tests/test_mlperf_log.py
@@ -1,0 +1,116 @@
+# Copyright 2019 MLBenchmark Group. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from contextlib import contextmanager
+import io
+import json
+import os
+import sys
+import time
+import unittest
+from unittest import mock
+
+from mlperf_compliance import constants
+from mlperf_compliance import mlperf_log
+from mlperf_compliance import validations
+
+@contextmanager
+def _captured_stdout():
+  cap_out = io.StringIO()
+  old_out = sys.stdout
+  try:
+    sys.stdout = cap_out
+    yield sys.stdout
+  finally:
+    sys.stdout = old_out
+
+class TestMlperfLog(unittest.TestCase):
+
+  def setUp(self):
+    self.origin_validate = validations.validate
+    validations.validate = mock.MagicMock(return_value=True)
+
+    self.origin_get_caller = mlperf_log.get_caller
+    mlperf_log.get_caller = mock.MagicMock(
+        return_value={"file": "mybenchmark/file.py", "lineno": 42})
+
+    self.origin_do_print = mlperf_log._do_print
+    mlperf_log._do_print = mock.Mock(side_effect=self._fake_do_print)
+
+    self.origin_time = time.time
+    time.time = mock.MagicMock(return_value=1558767599.999)
+
+  def tearDown(self):
+    validations.validate = self.origin_validate
+    mlperf_log.get_caller = self.origin_get_caller
+    mlperf_log._do_print = self.origin_do_print
+    time.time = self.origin_time
+
+  def _fake_do_print(self, key, message, extra_print=False):
+    print(message)
+
+  def test_mlperf_print_simple(self):
+    expected_output_l = ":::MLL 1558767599.999 run_start:"
+    expected_output_r = '{"value": null, ' + \
+        '"metadata": {"file": "mybenchmark/file.py", "lineno": 42}}'
+    with _captured_stdout() as out:
+      mlperf_log.mlperf_print(constants.RUN_START)
+      lines = out.getvalue().splitlines()
+      output_l = " ".join(lines[0].split(" ", 3)[0:3])
+      output_r = lines[0].split(" ", 3)[3]
+      self.assertEqual(output_l, expected_output_l)
+      self.assertDictEqual(json.loads(output_r), json.loads(expected_output_r))
+
+  def test_mlperf_print_with_value(self):
+    expected_output_l = ":::MLL 1558767599.999 eval_accuracy:"
+    expected_output_r = '{"value": 0.99, ' + \
+        '"metadata": {"file": "mybenchmark/file.py", "lineno": 42}}'
+    with _captured_stdout() as out:
+      mlperf_log.mlperf_print(constants.EVAL_ACCURACY, value=0.99)
+      lines = out.getvalue().splitlines()
+      output_l = " ".join(lines[0].split(" ", 3)[0:3])
+      output_r = lines[0].split(" ", 3)[3]
+      self.assertEqual(output_l, expected_output_l)
+      self.assertDictEqual(json.loads(output_r), json.loads(expected_output_r))
+
+  def test_mlperf_print_with_metadata(self):
+    expected_output_l = ":::MLL 1558767599.999 epoch_stop:"
+    expected_output_r = '{"value": null, "metadata": ' + \
+        '{"file": "mybenchmark/file.py", "lineno": 42, "first_epoch_num": 1}}'
+    with _captured_stdout() as out:
+      mlperf_log.mlperf_print(
+          constants.EPOCH_STOP, metadata={"first_epoch_num": 1})
+      lines = out.getvalue().splitlines()
+      output_l = " ".join(lines[0].split(" ", 3)[0:3])
+      output_r = lines[0].split(" ", 3)[3]
+      self.assertEqual(output_l, expected_output_l)
+      self.assertDictEqual(json.loads(output_r), json.loads(expected_output_r))
+
+def manual_test():
+  root_dir = os.path.normpath(
+      os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", ".."))
+
+  mlperf_log.setdefault(
+      benchmark="resnet", root_dir=root_dir, extra_print=True, prefix="TEST")
+  mlperf_log.mlperf_print(constants.RUN_START)
+  mlperf_log.mlperf_print(constants.EVAL_ACCURACY, value=0.99)
+  mlperf_log.mlperf_print(
+          constants.EPOCH_STOP, metadata={"first_epoch_num": 1})
+
+if __name__ == "__main__":
+  if len(sys.argv) > 1 and sys.argv[1] == "manual":
+    manual_test()
+  else:
+    unittest.main()

--- a/compliance/mlperf_compliance/tests/test_validations.py
+++ b/compliance/mlperf_compliance/tests/test_validations.py
@@ -1,0 +1,49 @@
+# Copyright 2019 MLBenchmark Group. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import unittest
+
+from mlperf_compliance import constants
+from mlperf_compliance import validations
+
+
+class TestValidations(unittest.TestCase):
+  
+  def test_validate_pass(self):
+    result = validations.validate(
+        key=constants.RUN_START,
+        value=None,
+        metadata=None,
+        benchmark=constants.RESNET)
+    self.assertEqual(result, True)
+
+  def test_validate_pass_unknown_benchmark(self):
+    result = validations.validate(
+        key="unknown_key",
+        value=None,
+        metadata=None,
+        benchmark="unknown_benchmark")
+    self.assertEqual(result, True)
+  
+  def test_validate_fail_unknown_key(self):
+    with self.assertRaises(ValueError):
+      validations.validate(
+          key="unknown_key",
+          value=None,
+          metadata=None,
+          benchmark=constants.RESNET)
+
+if __name__ == "__main__":
+  unittest.main()

--- a/compliance/mlperf_compliance/tf_mlperf_log.py
+++ b/compliance/mlperf_compliance/tf_mlperf_log.py
@@ -33,6 +33,8 @@ import tensorflow as tf
 def log_deferred(op, log_id, every_n=1, first_n=None):
   """Helper method inserting compliance logging ops.
 
+  DEPRECATED: No longer applicable for v0.6 submissions
+
   Note: This helper is not guaranteed to be efficient, as it will insert ops
         and control dependencies. If this proves to be a bottleneck, submitters
         may wish to consider other methods such as extracting values from an

--- a/compliance/mlperf_compliance/validations.py
+++ b/compliance/mlperf_compliance/validations.py
@@ -1,0 +1,35 @@
+# Copyright 2019 MLBenchmark Group. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from mlperf_compliance import constants
+from mlperf_compliance import constant_sets
+
+benchmark_key_sets = {
+  constants.RESNET: constant_sets.RESNET_KEY_SET,
+  constants.SSD: constant_sets.SSD_KEY_SET,
+  constants.MASKRCNN: constant_sets.MASKRCNN_KEY_SET,
+  constants.GNMT: constant_sets.GNMT_KEY_SET,
+  constants.TRANSFORMER: constant_sets.TRANSFORMER_KEY_SET,
+  constants.MINIGO: constant_sets.MINIGO_KEY_SET
+}
+
+def validate(key, value, metadata, benchmark=None):
+  key_set = set()
+  if benchmark is not None and benchmark in benchmark_key_sets:
+    key_set = benchmark_key_sets[benchmark]
+    if key not in key_set:
+      raise ValueError(
+          "Key \"{}\" is not in known {} keys.".format(key, benchmark))
+  return True

--- a/compliance/setup.py
+++ b/compliance/setup.py
@@ -20,7 +20,7 @@ with open("README.md", "r") as f:
 
 setuptools.setup(
     name="mlperf_compliance",
-    version="0.0.10",
+    version="0.6.0",
     author="Taylor Robie",
     author_email="taylorrobie@google.com",
     description="Tools for logging MLPerf compliance tags.",


### PR DESCRIPTION
This refactors mlperf_compliance package for v0.6. Main changes:

- use "mlperf_log.setdefault" to set default logging behaviors
- use "mlperf_log.mlperf_print" to log for any models (no more model specific methods)
- use "mlperf_log.constants" to find all needed constants in logs
- no longer support deferred logs for tf (all values are supposed to be static in 0.6)
- added readme for basic instructions
- added example to explain usage
- added some tests
- bumped version to 0.6.0 (main version same as training for easier future track)