### PR TITLE
Add multi-GPU support for Transformer

### DIFF
--- a/translation/tensorflow/Dockerfile
+++ b/translation/tensorflow/Dockerfile
@@ -1,18 +1,20 @@
-FROM nvidia/cuda:9.0-cudnn7-runtime-ubuntu16.04
+FROM nvidia/cuda:10.0-cudnn7-runtime-ubuntu18.04
 WORKDIR /research
-RUN apt-get update
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates \
     build-essential \
-    git \
-    python \
-    python-pip
+    python3.6 \
+    python3.6-dev \
+    python3-pip \
+    python3-setuptools
 ENV HOME /research
 ENV PYENV_ROOT $HOME/.pyenv
 ENV PATH $PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
-RUN apt-get install -y python-setuptools
-RUN apt-get install -y python-pip python3-pip virtualenv htop
-RUN pip3 install --upgrade numpy scipy sklearn tensorflow-gpu==1.9.0
+# use numpy 1.16.4 for better compatibility with tensorflow-gpu 1.14.0
+RUN pip3 install wheel && pip3 install \
+    numpy==1.16.4 \
+    scipy \
+    sklearn \
+    tensorflow-gpu==1.14.0
 
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
@@ -20,6 +22,4 @@ ENV LC_ALL C.UTF-8
 # Mount data into the docker
 ADD . /research/transformer
 WORKDIR /research/transformer
-RUN pip3 install -r requirements.txt
 ENTRYPOINT ["/bin/bash"]
-

--- a/translation/tensorflow/run_training.sh
+++ b/translation/tensorflow/run_training.sh
@@ -2,8 +2,59 @@
 
 set -e
 
-SEED=$1
-QUALITY=$2
+usage() {
+  echo \
+    Usage: run_training.sh \
+    [--random_seed RANDOM_SEED] \
+    [--bleu_threshold TARGET_BLEU_SCORE] \
+    [--num_gpus NUM_GPUS] \
+    [--distribution_strategy DISTRIBUTION_STRATEGY] \
+    [--all_reduce_alg ALL_REDUCE_ALGORITHM]
+}
+
+random_seed_arg=
+bleu_threshold_arg=
+num_gpus_arg=
+distribution_strategy_arg=
+all_reduce_alg_arg=
+
+while [ "$1" != "" ]; do
+  case $1 in
+    --random_seed )
+      shift
+      if [[ $1 == --* ]] ; then usage; exit 1; fi
+      if [ "$1" != "" ] ; then random_seed_arg="--random_seed=$1"; fi
+      ;;
+    --bleu_threshold )
+      shift
+      if [[ $1 == --* ]] ; then usage; exit 1; fi
+      if [ "$1" != "" ]; then bleu_threshold_arg="--bleu_threshold=$1"; fi
+      ;;
+    --num_gpus )
+      shift
+      if [[ $1 == --* ]] ; then usage; exit 1; fi
+      if [ "$1" != "" ]; then num_gpus_arg="--num_gpus=$1"; fi
+      ;;
+    --distribution_strategy )
+      shift
+      if [[ $1 == --* ]] ; then usage; exit 1; fi
+      if [ "$1" != "" ]; then distribution_strategy_arg="--distribution_strategy=$1"; fi
+      ;;
+    --all_reduce_alg )
+      shift
+      if [[ $1 == --* ]] ; then usage; exit 1; fi
+      if [ "$1" != "" ]; then all_reduce_alg_arg="--all_reduce_alg=$1"; fi
+      ;;
+    -h | --help )
+      usage
+      exit
+      ;;
+    * )
+      usage
+      exit 1
+  esac
+  shift
+done
 
 cd /research/transformer
 
@@ -11,4 +62,13 @@ export PYTHONPATH=/research/transformer/transformer:${PYTHONPATH}
 # Add compliance to PYTHONPATH
 # export PYTHONPATH=/mlperf/training/compliance:${PYTHONPATH}
 
-python3 transformer/transformer_main.py --random_seed=${SEED} --data_dir=processed_data/ --model_dir=model --params=big --bleu_threshold ${QUALITY} --bleu_source=newstest2014.en --bleu_ref=newstest2014.de
+python3 transformer/transformer_main.py \
+  --data_dir=processed_data/ \
+  --model_dir=model --params=big \
+  --bleu_source=newstest2014.en \
+  --bleu_ref=newstest2014.de \
+  ${random_seed_arg} \
+  ${bleu_threshold_arg} \
+  ${num_gpus_arg} \
+  ${distribution_strategy_arg} \
+  ${all_reduce_alg_arg}

--- a/translation/tensorflow/transformer/model/model_params.py
+++ b/translation/tensorflow/transformer/model/model_params.py
@@ -19,6 +19,7 @@ class TransformerBaseParams(object):
   """Parameters for the base Transformer model."""
   # Input params
   batch_size = 2048  # Maximum number of tokens per batch of examples.
+                     # In a multi-GPU setting, this is per-GPU batch size.
   max_length = 256  # Maximum number of tokens per example.
 
   # Model params

--- a/translation/tensorflow/transformer/utils/distribution_utils.py
+++ b/translation/tensorflow/transformer/utils/distribution_utils.py
@@ -1,0 +1,122 @@
+# Copyright 2019 MLBenchmark Group. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Helper functions for distributed setting."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import tensorflow as tf
+
+
+def _mirrored_cross_device_ops(all_reduce_alg, num_packs):
+  """Return a CrossDeviceOps based on all_reduce_alg and num_packs.
+  Args:
+    all_reduce_alg: a string specifying which cross device op to pick, or None.
+    num_packs: an integer specifying number of packs for the cross device op.
+  Returns:
+    tf.distribute.CrossDeviceOps object or None.
+  Raises:
+    ValueError: if `all_reduce_alg` not in [None, 'nccl', 'hierarchical_copy'].
+  """
+  if all_reduce_alg is None:
+    return None
+  mirrored_all_reduce_options = {
+      "nccl": tf.distribute.NcclAllReduce,
+      "hierarchical_copy": tf.distribute.HierarchicalCopyAllReduce
+  }
+  if all_reduce_alg not in mirrored_all_reduce_options:
+    raise ValueError(
+        "When used with `mirrored`, valid values for all_reduce_alg are "
+        "['nccl', 'hierarchical_copy'].  Supplied value: {}".format(
+            all_reduce_alg))
+  cross_device_ops_class = mirrored_all_reduce_options[all_reduce_alg]
+  return cross_device_ops_class(num_packs=num_packs)
+
+
+def get_num_gpus(num_gpus):
+  """Validate and return number of GPUs.
+  Args:
+    num_gpus: The number of GPUs requested
+  Returns:
+    num_gpus if num_gpus is non-negative int.
+    0 or 1, depending on GPU availability, if num_gpus is None.
+  Raises:
+    ValueError: if num_gpu is not None or non-negative int.
+  """
+  if num_gpus is not None and (not isinstance(num_gpus, int) or num_gpus < 0):
+    raise ValueError("`num_gpus` must be a non-negative int or None.")
+  if num_gpus is None:
+    if tf.test.is_gpu_available():
+      return 1
+    return 0
+  return num_gpus
+
+
+def get_distribution_strategy(distribution_strategy=None,
+                              num_gpus=0,
+                              all_reduce_alg=None,
+                              num_packs=1):
+  """Return a DistributionStrategy for running the model.
+  Args:
+    distribution_strategy: Specifies which distribution strategy to use.
+      Accepted values are 'one_device', 'mirrored', and 'parameter_server'.
+    num_gpus: Number of GPUs to run this model.
+    all_reduce_alg: Optional. Specifies which algorithm to use when performing
+      all-reduce. For `MirroredStrategy`, valid values are "nccl" and
+      "hierarchical_copy".
+    num_packs: Optional. Sets the `num_packs` in `tf.distribute.NcclAllReduce`
+      or `tf.distribute.HierarchicalCopyAllReduce` for `MirroredStrategy`.
+  Returns:
+    tf.distribute.DistibutionStrategy object.
+  Raises:
+    ValueError: if `distribution_strategy` is None or 'one_device' and
+      `num_gpus` is larger than 1.
+  """
+  if num_gpus < 0:
+    raise ValueError("`num_gpus` can not be negative.")
+
+  if distribution_strategy is None:
+    if num_gpus > 1:
+      raise ValueError(
+          "When {} GPUs are specified, distribution_strategy "
+          "flag cannot be None.".format(num_gpus))
+    return None
+  
+  distribution_strategy = distribution_strategy.lower()
+
+  if distribution_strategy == "one_device":
+    if num_gpus == 0:
+      return tf.distribute.OneDeviceStrategy("device:CPU:0")
+    else:
+      if num_gpus > 1:
+        raise ValueError("`OneDeviceStrategy` can not be used for more than "
+                         "one device.")
+      return tf.distribute.OneDeviceStrategy("device:GPU:0")
+
+  if distribution_strategy == "mirrored":
+    if num_gpus == 0:
+      devices = ["device:CPU:0"]
+    else:
+      devices = ["device:GPU:%d" % i for i in range(num_gpus)]
+    return tf.distribute.MirroredStrategy(
+        devices=devices,
+        cross_device_ops=_mirrored_cross_device_ops(all_reduce_alg, num_packs))
+
+  if distribution_strategy == "parameter_server":
+    return tf.distribute.experimental.ParameterServerStrategy()
+
+  raise ValueError(
+      "Unrecognized Distribution Strategy: %r" % distribution_strategy)

--- a/translation/tensorflow/transformer/utils/distribution_utils_test.py
+++ b/translation/tensorflow/transformer/utils/distribution_utils_test.py
@@ -1,0 +1,79 @@
+# Copyright 2019 MLBenchmark Group. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+""" Tests for distribution util functions."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import tensorflow as tf
+
+import distribution_utils
+
+mock = tf.compat.v1.test.mock
+
+
+class GetNumGPUsTest(tf.test.TestCase):
+  """Tests for get_num_gpus."""
+  def test_zero_gpu(self):
+    num = distribution_utils.get_num_gpus(num_gpus=0)
+    self.assertEqual(num, 0)
+
+  def test_one_gpu(self):
+    num = distribution_utils.get_num_gpus(num_gpus=1)
+    self.assertEqual(num, 1)
+
+  def test_multi_gpu(self):
+    num = distribution_utils.get_num_gpus(num_gpus=5)
+    self.assertEqual(num, 5)
+
+  @mock.patch("tensorflow.test.is_gpu_available", return_value=True)
+  def test_default_available_gpu(self, mock_is_gpu_available):
+    num = distribution_utils.get_num_gpus(num_gpus=None)
+    self.assertEqual(num, 1)
+
+  @mock.patch("tensorflow.test.is_gpu_available", return_value=False)
+  def test_default_unavailable_gpu(self, mock_is_gpu_available):
+    num = distribution_utils.get_num_gpus(num_gpus=None)
+    self.assertEqual(num, 0)
+
+
+class GetDistributionStrategyTest(tf.test.TestCase):
+  """Tests for get_distribution_strategy."""
+  def test_one_device_strategy_cpu(self):
+    ds = distribution_utils.get_distribution_strategy(
+        distribution_strategy="one_device", num_gpus=0)
+    self.assertEqual(ds.num_replicas_in_sync, 1)
+    self.assertEqual(len(ds.extended.worker_devices), 1)
+    self.assertIn('CPU', ds.extended.worker_devices[0])
+
+  def test_one_device_strategy_gpu(self):
+    ds = distribution_utils.get_distribution_strategy(
+        distribution_strategy="one_device", num_gpus=1)
+    self.assertEqual(ds.num_replicas_in_sync, 1)
+    self.assertEqual(len(ds.extended.worker_devices), 1)
+    self.assertIn('GPU', ds.extended.worker_devices[0])
+
+  def test_mirrored_strategy(self):
+    ds = distribution_utils.get_distribution_strategy(
+        distribution_strategy="mirrored", num_gpus=5)
+    self.assertEqual(ds.num_replicas_in_sync, 5)
+    self.assertEqual(len(ds.extended.worker_devices), 5)
+    for device in ds.extended.worker_devices:
+      self.assertIn('GPU', device)
+
+
+if __name__ == "__main__":
+  tf.test.main()

--- a/translation/tensorflow/transformer/utils/metrics.py
+++ b/translation/tensorflow/transformer/utils/metrics.py
@@ -61,11 +61,11 @@ def padded_cross_entropy_loss(logits, labels, smoothing, vocab_size):
     Returns a float32 tensor with shape
       [batch_size, max(length_logits, length_labels)]
   """
-  with tf.name_scope("loss", [logits, labels]):
+  with tf.name_scope("loss", values=[logits, labels]):
     logits, labels = _pad_tensors_to_same_length(logits, labels)
 
     # Calculate smoothing cross entropy
-    with tf.name_scope("smoothing_cross_entropy", [logits, labels]):
+    with tf.name_scope("smoothing_cross_entropy", values=[logits, labels]):
       confidence = 1.0 - smoothing
       low_confidence = (1.0 - confidence) / tf.to_float(vocab_size - 1)
       soft_targets = tf.one_hot(


### PR DESCRIPTION
This patch adds multi-GPU support for the Transformer model.
The following changes are included:

- model files
  - add multi device support in the main module
  - add command-line options for gpu number, distribution strategy, all reduce algo
  - update tf version to 1.14 and minor fixings to adapt to that
- dockerfile
  - cleanups and adapt to multi gpu changes
- run scripts
  - cleanups, improve command line options to make passing arguments easier
  - add support for multi gpu training