### PR TITLE
GNMT reference update

### DIFF
--- a/rnn_translator/pytorch/Dockerfile
+++ b/rnn_translator/pytorch/Dockerfile
@@ -3,7 +3,10 @@ FROM pytorch/pytorch:1.0.1-cuda10.0-cudnn7-runtime
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
 
-ADD . /workspace/pytorch
 WORKDIR /workspace/pytorch
 
+COPY requirements.txt .
+
 RUN pip install -r requirements.txt
+
+COPY . .

--- a/rnn_translator/pytorch/requirements.txt
+++ b/rnn_translator/pytorch/requirements.txt
@@ -1,3 +1,3 @@
 sacrebleu==1.2.10
 git+git://github.com/NVIDIA/apex.git@9041a868a1a253172d94b113a963375b9badd030#egg=apex
-git+git://github.com/mlperf/training@00570abf77d351e474d57830014f6a3e501dece1#subdirectory=compliance
+git+https://github.com/mlperf/logging.git@44d26ff1341eaf7ed5a7105176c8ccc36e088d59

--- a/rnn_translator/pytorch/requirements.txt
+++ b/rnn_translator/pytorch/requirements.txt
@@ -1,3 +1,3 @@
 sacrebleu==1.2.10
 git+git://github.com/NVIDIA/apex.git@9041a868a1a253172d94b113a963375b9badd030#egg=apex
-mlperf-compliance==0.0.10
+git+git://github.com/mlperf/training@00570abf77d351e474d57830014f6a3e501dece1#subdirectory=compliance

--- a/rnn_translator/pytorch/run.sh
+++ b/rnn_translator/pytorch/run.sh
@@ -46,6 +46,12 @@ while [ "$1" != "" ]; do
   shift
 done
 
+# clear your caches here
+python -c \
+'from seq2seq.utils import gnmt_event;'\
+'from mllog import constants;'\
+'gnmt_event(constants.CACHE_CLEAR, value=True)'
+
 # run training
 python3 $MULTI_GPU_WRAPPER train.py \
   --dataset-dir ${DATASET_DIR} \

--- a/rnn_translator/pytorch/run.sh
+++ b/rnn_translator/pytorch/run.sh
@@ -4,11 +4,51 @@ set -e
 
 DATASET_DIR='/data'
 
-SEED=${1:-"1"}
-TARGET=${2:-"24.00"}
+usage() {
+  echo \
+    Usage: run.sh \
+    [--random_seed RANDOM_SEED] \
+    [--bleu_threshold TARGET_BLEU_SCORE] \
+    [--num_gpus NUM_GPUS]
+}
+
+SEED=1
+TARGET=24.00
+MULTI_GPU_WRAPPER=
+
+MULTI_GPU_COMMAND='-m torch.distributed.launch --nproc_per_node'
+
+while [ "$1" != "" ]; do
+  case $1 in
+    --random_seed )
+      shift
+      if [[ $1 == --* ]] ; then usage; exit 1; fi
+      if [ "$1" != "" ] ; then SEED=$1; fi
+      ;;
+    --bleu_threshold )
+      shift
+      if [[ $1 == --* ]] ; then usage; exit 1; fi
+      if [ "$1" != "" ]; then TARGET=$1; fi
+      ;;
+    --num_gpus )
+      shift
+      if [[ $1 == --* ]] ; then usage; exit 1; fi
+      if [ "$1" != "" ] && [ "$1" != "1" ] ; then MULTI_GPU_WRAPPER="$MULTI_GPU_COMMAND $1"; fi
+      ;;
+    -h | --help )
+      usage
+      exit
+      ;;
+    * )
+      usage
+      exit 1
+  esac
+  shift
+done
 
 # run training
-python3 train.py \
+python3 $MULTI_GPU_WRAPPER train.py \
   --dataset-dir ${DATASET_DIR} \
   --seed $SEED \
+  --train-global-batch-size 1024 \
   --target-bleu $TARGET

--- a/rnn_translator/pytorch/run.sh
+++ b/rnn_translator/pytorch/run.sh
@@ -49,7 +49,7 @@ done
 # clear your caches here
 python -c \
 'from seq2seq.utils import gnmt_event;'\
-'from mllog import constants;'\
+'from mlperf_logging.mllog import constants;'\
 'gnmt_event(constants.CACHE_CLEAR, value=True)'
 
 # run training

--- a/rnn_translator/pytorch/run_and_time.sh
+++ b/rnn_translator/pytorch/run_and_time.sh
@@ -1,22 +1,61 @@
 #!/bin/bash
 
-# runs benchmark and reports time to convergence
-# to use the script:
-#   run_and_time.sh
-
 set -e
+
+DEFAULT_SEED=1
+DEFAULT_TARGET_UNCASED_BLEU_SCORE=24.00
+
+usage() {
+  echo \
+    Usage: run_and_time.sh \
+    [--random_seed RANDOM_SEED] \
+    [--bleu_threshold TARGET_BLEU_SCORE] \
+    [--num_gpus NUM_GPUS]
+}
+
+seed=${DEFAULT_SEED}
+random_seed_arg="--random_seed ${DEFAULT_SEED}"
+bleu_threshold_arg="--bleu_threshold ${DEFAULT_TARGET_UNCASED_BLEU_SCORE}"
+num_gpus_arg=
+
+while [ "$1" != "" ]; do
+  case $1 in
+    --random_seed )
+      shift
+      if [[ $1 == --* ]] ; then usage; exit 1; fi
+      if [ "$1" != "" ] ; then random_seed_arg="--random_seed $1"; seed=$1; fi
+      ;;
+    --bleu_threshold )
+      shift
+      if [[ $1 == --* ]] ; then usage; exit 1; fi
+      if [ "$1" != "" ]; then bleu_threshold_arg="--bleu_threshold $1"; fi
+      ;;
+    --num_gpus )
+      shift
+      if [[ $1 == --* ]] ; then usage; exit 1; fi
+      if [ "$1" != "" ]; then num_gpus_arg="--num_gpus $1"; fi
+      ;;
+    -h | --help )
+      usage
+      exit
+      ;;
+    * )
+      usage
+      exit 1
+  esac
+  shift
+done
 
 # start timing
 start=$(date +%s)
 start_fmt=$(date +%Y-%m-%d\ %r)
 echo "STARTING TIMING RUN AT $start_fmt"
 
-# run benchmark
-seed=${1:-"1"}
-target=24.00
-
 echo "running benchmark"
-./run.sh $seed $target
+./run.sh \
+  ${random_seed_arg} \
+  ${bleu_threshold_arg} \
+  ${num_gpus_arg}
 
 sleep 3
 ret_code=$?; if [[ $ret_code != 0 ]]; then exit $ret_code; fi

--- a/rnn_translator/pytorch/seq2seq/data/sampler.py
+++ b/rnn_translator/pytorch/seq2seq/data/sampler.py
@@ -1,12 +1,10 @@
 import logging
 
 import torch
-from mlperf_compliance import mlperf_log
 from torch.utils.data.sampler import Sampler
 
 from seq2seq.utils import get_rank
 from seq2seq.utils import get_world_size
-from seq2seq.utils import gnmt_print
 
 
 class DistributedSampler(Sampler):
@@ -81,7 +79,6 @@ class DistributedSampler(Sampler):
         return indices
 
     def __iter__(self):
-        gnmt_print(key=mlperf_log.INPUT_ORDER, sync=False)
         rng = self.init_rng()
         # generate permutation
         indices = torch.randperm(self.data_len, generator=rng)
@@ -127,7 +124,6 @@ class ShardingSampler(DistributedSampler):
             * self.global_batch_size
 
     def __iter__(self):
-        gnmt_print(key=mlperf_log.INPUT_ORDER, sync=False)
         rng = self.init_rng()
         # generate permutation
         indices = torch.randperm(self.data_len, generator=rng)
@@ -202,7 +198,6 @@ class BucketingSampler(DistributedSampler):
             self.num_samples += samples
 
     def __iter__(self):
-        gnmt_print(key=mlperf_log.INPUT_ORDER, sync=False)
         rng = self.init_rng()
         global_bs = self.global_batch_size
 
@@ -251,7 +246,6 @@ class StaticDistributedSampler(Sampler):
 
         global_batch_size = batch_size * world_size
 
-        gnmt_print(key=mlperf_log.INPUT_ORDER, sync=False)
         data_len = len(dataset)
         num_samples = (data_len + global_batch_size - 1) \
             // global_batch_size * global_batch_size

--- a/rnn_translator/pytorch/seq2seq/inference/beam_search.py
+++ b/rnn_translator/pytorch/seq2seq/inference/beam_search.py
@@ -1,9 +1,7 @@
 import torch
-from mlperf_compliance import mlperf_log
 
 from seq2seq.data.config import BOS
 from seq2seq.data.config import EOS
-from seq2seq.utils import gnmt_print
 
 
 class SequenceGenerator:
@@ -38,17 +36,6 @@ class SequenceGenerator:
         self.cov_penalty_factor = cov_penalty_factor
 
         self.batch_first = self.model.batch_first
-
-        gnmt_print(key=mlperf_log.EVAL_HP_BEAM_SIZE,
-                   value=self.beam_size, sync=False)
-        gnmt_print(key=mlperf_log.EVAL_HP_MAX_SEQ_LEN,
-                   value=self.max_seq_len, sync=False)
-        gnmt_print(key=mlperf_log.EVAL_HP_LEN_NORM_CONST,
-                   value=self.len_norm_const, sync=False)
-        gnmt_print(key=mlperf_log.EVAL_HP_LEN_NORM_FACTOR,
-                   value=self.len_norm_factor, sync=False)
-        gnmt_print(key=mlperf_log.EVAL_HP_COV_PENALTY_FACTOR,
-                   value=self.cov_penalty_factor, sync=False)
 
     def greedy_search(self, batch_size, initial_input, initial_context=None):
         """

--- a/rnn_translator/pytorch/seq2seq/models/gnmt.py
+++ b/rnn_translator/pytorch/seq2seq/models/gnmt.py
@@ -1,11 +1,9 @@
 import torch.nn as nn
-from mlperf_compliance import mlperf_log
 
 import seq2seq.data.config as config
 from seq2seq.models.decoder import ResidualRecurrentDecoder
 from seq2seq.models.encoder import ResidualRecurrentEncoder
 from seq2seq.models.seq2seq_base import Seq2Seq
-from seq2seq.utils import gnmt_print
 
 
 class GNMT(Seq2Seq):
@@ -29,13 +27,6 @@ class GNMT(Seq2Seq):
         """
 
         super(GNMT, self).__init__(batch_first=batch_first)
-
-        gnmt_print(key=mlperf_log.MODEL_HP_NUM_LAYERS,
-                   value=num_layers, sync=False)
-        gnmt_print(key=mlperf_log.MODEL_HP_HIDDEN_SIZE,
-                   value=hidden_size, sync=False)
-        gnmt_print(key=mlperf_log.MODEL_HP_DROPOUT,
-                   value=dropout, sync=False)
 
         if share_embedding:
             embedder = nn.Embedding(vocab_size, hidden_size,

--- a/rnn_translator/pytorch/seq2seq/train/lr_scheduler.py
+++ b/rnn_translator/pytorch/seq2seq/train/lr_scheduler.py
@@ -2,9 +2,9 @@ import logging
 import math
 
 import torch
-from mlperf_compliance import mlperf_log
+from mllog import constants
 
-from seq2seq.utils import gnmt_print
+from seq2seq.utils import gnmt_event
 
 
 def perhaps_convert_float(param, total):
@@ -74,7 +74,7 @@ class WarmupMultiStepLR(torch.optim.lr_scheduler._LRScheduler):
                          f'remain_steps, setting warmup_steps=remain_steps')
             self.warmup_steps = self.remain_steps
 
-        gnmt_print(key=mlperf_log.OPT_LR_WARMUP_STEPS, value=self.warmup_steps,
+        gnmt_event(key=constants.OPT_LR_WARMUP_STEPS, value=self.warmup_steps,
                    sync=False)
 
         super(WarmupMultiStepLR, self).__init__(optimizer, last_epoch)

--- a/rnn_translator/pytorch/seq2seq/train/lr_scheduler.py
+++ b/rnn_translator/pytorch/seq2seq/train/lr_scheduler.py
@@ -2,7 +2,7 @@ import logging
 import math
 
 import torch
-from mllog import constants
+from mlperf_logging.mllog import constants
 
 from seq2seq.utils import gnmt_event
 

--- a/rnn_translator/pytorch/seq2seq/train/lr_scheduler.py
+++ b/rnn_translator/pytorch/seq2seq/train/lr_scheduler.py
@@ -74,8 +74,21 @@ class WarmupMultiStepLR(torch.optim.lr_scheduler._LRScheduler):
                          f'remain_steps, setting warmup_steps=remain_steps')
             self.warmup_steps = self.remain_steps
 
-        gnmt_event(key=constants.OPT_LR_WARMUP_STEPS, value=self.warmup_steps,
-                   sync=False)
+        gnmt_event(key=constants.OPT_LR_ALT_DECAY_FUNC,
+                     value=True)
+        gnmt_event(key=constants.OPT_LR_ALT_WARMUP_FUNC,
+                     value=True)
+
+        gnmt_event(key=constants.OPT_LR_DECAY_INTERVAL,
+                     value=self.decay_interval)
+        gnmt_event(key=constants.OPT_LR_DECAY_FACTOR,
+                     value=self.decay_factor)
+        gnmt_event(key=constants.OPT_LR_DECAY_STEPS,
+                     value=self.decay_steps)
+        gnmt_event(key=constants.OPT_LR_REMAIN_STEPS,
+                     value=self.remain_steps)
+        gnmt_event(key=constants.OPT_LR_WARMUP_STEPS,
+                     value=self.warmup_steps)
 
         super(WarmupMultiStepLR, self).__init__(optimizer, last_epoch)
 

--- a/rnn_translator/pytorch/seq2seq/train/trainer.py
+++ b/rnn_translator/pytorch/seq2seq/train/trainer.py
@@ -310,6 +310,12 @@ class Seq2SeqTrainer:
         torch.set_grad_enabled(True)
         self.model.train()
         torch.cuda.empty_cache()
+
+        gnmt_event(key='epoch_training_samples',
+                   value=len(data_loader) * data_loader.batch_size,
+                   metadata={'epoch_num': self.epoch + 1 },
+                   sync=False)
+
         self.preallocate(data_loader, training=True)
         output = self.feed_data(data_loader, training=True)
         self.model.zero_grad()

--- a/rnn_translator/pytorch/seq2seq/train/trainer.py
+++ b/rnn_translator/pytorch/seq2seq/train/trainer.py
@@ -8,13 +8,13 @@ import torch
 import torch.optim
 import torch.utils.data
 from apex.parallel import DistributedDataParallel as DDP
-from mlperf_compliance import mlperf_log
+from mllog import constants
 
 from seq2seq.train.fp_optimizers import Fp16Optimizer
 from seq2seq.train.fp_optimizers import Fp32Optimizer
 from seq2seq.train.lr_scheduler import WarmupMultiStepLR
 from seq2seq.utils import AverageMeter
-from seq2seq.utils import gnmt_print
+from seq2seq.utils import gnmt_event
 from seq2seq.utils import sync_workers
 
 
@@ -111,15 +111,15 @@ class Seq2SeqTrainer:
         opt_name = opt_config.pop('optimizer')
         self.optimizer = torch.optim.__dict__[opt_name](params, **opt_config)
         logging.info(f'Using optimizer: {self.optimizer}')
-        gnmt_print(key=mlperf_log.OPT_NAME,
-                   value=mlperf_log.ADAM, sync=False)
-        gnmt_print(key=mlperf_log.OPT_LR,
+        gnmt_event(key=constants.OPT_NAME,
+                   value=constants.ADAM, sync=False)
+        gnmt_event(key=constants.OPT_BASE_LR,
                    value=opt_config['lr'], sync=False)
-        gnmt_print(key=mlperf_log.OPT_HP_ADAM_BETA1,
+        gnmt_event(key=constants.OPT_ADAM_BETA_1,
                    value=self.optimizer.defaults['betas'][0], sync=False)
-        gnmt_print(key=mlperf_log.OPT_HP_ADAM_BETA2,
+        gnmt_event(key=constants.OPT_ADAM_BETA_2,
                    value=self.optimizer.defaults['betas'][1], sync=False)
-        gnmt_print(key=mlperf_log.OPT_HP_ADAM_EPSILON,
+        gnmt_event(key=constants.OPT_ADAM_EPSILON,
                    value=self.optimizer.defaults['eps'], sync=False)
 
         self.scheduler = WarmupMultiStepLR(self.optimizer, train_iterations,

--- a/rnn_translator/pytorch/seq2seq/train/trainer.py
+++ b/rnn_translator/pytorch/seq2seq/train/trainer.py
@@ -8,7 +8,7 @@ import torch
 import torch.optim
 import torch.utils.data
 from apex.parallel import DistributedDataParallel as DDP
-from mllog import constants
+from mlperf_logging.mllog import constants
 
 from seq2seq.train.fp_optimizers import Fp16Optimizer
 from seq2seq.train.fp_optimizers import Fp32Optimizer

--- a/rnn_translator/pytorch/seq2seq/utils.py
+++ b/rnn_translator/pytorch/seq2seq/utils.py
@@ -37,6 +37,27 @@ def _gnmt_print(logger, *args, **kwargs):
     if get_rank() == 0:
         logger(*args, **kwargs, stack_offset=3)
 
+def mlperf_submission_log(benchmark):
+    gnmt_event(
+        key=mllog.constants.SUBMISSION_BENCHMARK,
+        value=benchmark,
+        )
+
+    gnmt_event(
+        key=mllog.constants.SUBMISSION_ORG,
+        value='your-company')
+
+    gnmt_event(
+        key=mllog.constants.SUBMISSION_DIVISION,
+        value='closed')
+
+    gnmt_event(
+        key=mllog.constants.SUBMISSION_STATUS,
+        value='onprem')
+
+    gnmt_event(
+        key=mllog.constants.SUBMISSION_PLATFORM,
+        value=f'your_platform')
 
 def init_lstm_(lstm, init_weight=0.1):
     """

--- a/rnn_translator/pytorch/seq2seq/utils.py
+++ b/rnn_translator/pytorch/seq2seq/utils.py
@@ -12,7 +12,7 @@ import torch.nn.init as init
 import torch.utils.collect_env
 
 
-import mllog
+from mlperf_logging import mllog
 
 mllogger = mllog.get_mllogger()
 

--- a/rnn_translator/pytorch/train.py
+++ b/rnn_translator/pytorch/train.py
@@ -9,8 +9,8 @@ import torch.nn as nn
 import torch.nn.parallel
 import torch.optim
 import torch.utils.data.distributed
-import mllog
-from mllog import constants
+from mlperf_logging import mllog
+from mlperf_logging.mllog import constants
 
 import seq2seq.data.config as config
 import seq2seq.train.trainer as trainers


### PR DESCRIPTION
Including changes
- the new logging client from #307 is used instead of the previous one
- removed lines logging keys not present in the latest logging spec
- compliance package is installed from a fork until #310 will be merged
- compliant with the updated checker #361 
- multi-GPU support through `run.sh` (`--num_gpus` flag like in #298 )