### PR TITLE
Fix race condition in Minigo selfplay

### DIFF
--- a/reinforcement/tensorflow/minigo/cc/concurrent_selfplay.cc
+++ b/reinforcement/tensorflow/minigo/cc/concurrent_selfplay.cc
@@ -855,7 +855,12 @@ void Selfplayer::ExecuteSharded(std::function<void(int, int)> fn) {
 std::unique_ptr<Model> Selfplayer::AcquireModel() { return models_.Pop(); }
 
 void Selfplayer::ReleaseModel(std::unique_ptr<Model> model) {
-  if (model->name() == latest_model_name_) {
+  bool keep_model;
+  {
+    absl::MutexLock lock(&mutex_);
+    keep_model = model->name() == latest_model_name_;
+  }
+  if (keep_model) {
     models_.Push(std::move(model));
   }
 }


### PR DESCRIPTION
`latest_model_name_` access must be protected by `mutex_`.

I'm currently running the benchmark to verify that it still converges.