### PR TITLE
centos-based Dockerfile for object-detection

### DIFF
--- a/object_detection/Dockerfile_centos
+++ b/object_detection/Dockerfile_centos
@@ -1,0 +1,105 @@
+FROM nvidia/cuda:10.0-cudnn7-devel-centos7
+#FROM nvidia/cuda:10.0-cudnn7-devel-ubi7
+
+WORKDIR /mlperf
+
+ENV CUDA_HOME /usr/local/cuda
+ENV LD_LIBRARY_PATH $LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64
+ENV PATH $PATH:$CUDA_HOME/bin
+ENV PYENV_ROOT $HOME/.pyenv
+ENV PATH $PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
+
+RUN yum install -y centos-release-scl && \
+    yum install devtoolset-7 rh-python36 -y
+
+# install basics
+RUN yum update -y && yum install -y \
+    ca-certificates \
+    build-essential \
+    git \
+    curl \
+    wget \
+    unzip \
+    which \
+    libXext libSM libXrender
+
+RUN source scl_source enable rh-python36 devtoolset-7 && \
+    pip install --upgrade pip && \
+    pip install yacs==0.1.5 \
+      cython==0.29.5 \
+      matplotlib==3.0.2 \
+      opencv-python==4.0.0.21 \
+      mlperf_compliance==0.0.10 \
+      gsutil \
+      Pillow==5.4.1 \
+      tqdm==4.19.9 \
+      numpy \
+      ipython==7.2.0 \
+      torch==1.0.1.post2 \
+      torchvision==0.2.2 \
+      ninja==1.8.2.post2 
+
+ADD . /mlperf
+
+# install pycocotools
+RUN source scl_source enable rh-python36 devtoolset-7 && \
+    git clone https://github.com/cocodataset/cocoapi.git && \
+    python --version && \
+    cd cocoapi/PythonAPI && \
+    python setup.py build_ext install
+
+# setup object-detection code
+RUN source scl_source enable rh-python36 devtoolset-7 && \
+    cd object_detection/ && \
+    pip uninstall -y torch; pip uninstall -y torch && \
+    pip install torch==1.0.1.post2 && \
+    cd pytorch && \
+    python setup.py build develop
+
+# For information purposes only, these are the versions of the packages which we've successfully used:
+# $ pip list
+# Package              Version           Location
+# -------------------- ----------------- -------------------------------------------------
+# backcall             0.1.0
+# certifi              2018.11.29
+# cffi                 1.11.5
+# cycler               0.10.0
+# Cython               0.29.5
+# decorator            4.3.2
+# fairseq              0.6.0             /scratch/fairseq
+# ipython              7.2.0
+# ipython-genutils     0.2.0
+# jedi                 0.13.2
+# kiwisolver           1.0.1
+# maskrcnn-benchmark   0.1               /scratch/mlperf/training/object_detection/pytorch
+# matplotlib           3.0.2
+# mkl-fft              1.0.10
+# mkl-random           1.0.2
+# mlperf-compliance    0.0.10
+# ninja                1.8.2.post2
+# numpy                1.16.1
+# opencv-python        4.0.0.21
+# parso                0.3.2
+# pexpect              4.6.0
+# pickleshare          0.7.5
+# Pillow               5.4.1
+# pip                  19.0.1
+# prompt-toolkit       2.0.8
+# ptyprocess           0.6.0
+# pycocotools          2.0
+# pycparser            2.19
+# Pygments             2.3.1
+# pyparsing            2.3.1
+# python-dateutil      2.8.0
+# pytorch-quantization 0.2.1
+# PyYAML               3.13
+# setuptools           40.8.0
+# six                  1.12.0
+# torch                1.0.0.dev20190225
+# torchvision          0.2.1
+# tqdm                 4.31.1
+# traitlets            4.3.2
+# wcwidth              0.1.7
+# wheel                0.32.3
+# yacs                 0.1.5
+

--- a/object_detection/README.md
+++ b/object_detection/README.md
@@ -16,16 +16,29 @@ git clone https://github.com/mlperf/training.git
 source training/install_cuda_docker.sh
 ```
 3. Build the docker image for the object detection task
+
+For Dockerfile (Ubuntu)
 ```
 cd training/object_detection/
 nvidia-docker build . -t mlperf/object_detection
 ```
 
+For Dockerfile_centos (CentOS)
+```
+cd training/object_detection/
+nvidia-docker build . -f object_detection/Dockerfile_rhel -t mlperf/object_detection
+```
+
 4. Run docker container and install code
+
+For Dockerfile (Ubuntu)
 ```
 nvidia-docker run -v .:/workspace -t -i --rm --ipc=host mlperf/object_detection \
     "cd mlperf/training/object_detection && ./install.sh"
 ```
+
+Dockerfile_centos (CentOS) runs the commands from `install.sh` during build, so there is no reason to run it separately.
+
 Now exit the docker container (Ctrl-D) to get back to your host.
 
 ### Steps to download data
@@ -35,9 +48,18 @@ source download_dataset.sh
 ```
 
 ### Steps to run benchmark.
+For Dockerfile (Ubuntu)
 ```
 nvidia-docker run -v .:/workspace -t -i --rm --ipc=host mlperf/object_detection \
     "cd mlperf/training/object_detection && ./run_and_time.sh"
+```
+
+For Dockerfile_centos (CentOS)
+```
+nvidia-docker run -t -i --rm --ipc=host object-detection \
+	"cd object_detection &&
+	source scl_source enable rh-python36 devtoolset-7 &&
+	./run_and_time.sh"
 ```
 
 # 3. Dataset/Environment


### PR DESCRIPTION
Adding another Dockerfile for the object-detection benchmark, with a CentOS base image.
Dockerfile_centos is meant to provide users flexibility with regards to the operating system used to run the benchmark application.
I've attached the docker build logs, and the beginning of the training logs for this dockerfile.
[build-logs.txt](https://github.com/mlperf/training/files/4512861/build-logs.txt)
[run-logs.txt](https://github.com/mlperf/training/files/4512862/run-logs.txt)


