### PR TITLE
Changed Dockerfile for image classification to use specific versions of python modules, made a change in resnet_run_loop.py

### DIFF
--- a/image_classification/tensorflow/Dockerfile
+++ b/image_classification/tensorflow/Dockerfile
@@ -10,7 +10,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     git \
     python \
-    python-pip
+    python-pip \
+    python3-dev  
+
+COPY ./nccl-repo-ubuntu1604-2.5.6-ga-cuda9.0_1-1_amd64.deb /
+RUN apt-get install libnccl2=2.5.6-1+cuda9.0 libnccl-dev=2.5.6-1+cuda9.0
 
 
 ENV HOME /research
@@ -21,7 +25,7 @@ ENV PATH $PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
 RUN apt-get install -y python-setuptools
 
 RUN apt-get install -y python-pip python3-pip virtualenv htop
-RUN pip3 install --upgrade numpy scipy sklearn tf-nightly-gpu
+RUN pip3 install --upgrade numpy==1.16.4 scipy==0.16.1 scikit-learn==0.22.2.post1 futures==3.1.1 h5py==2.10.0 google-crc32c==1.0.0 tensorflow-gpu==1.10.0
 
 
 # Mount data into the docker
@@ -32,5 +36,5 @@ WORKDIR /research/resnet
 RUN pip3 install -r official/requirements.txt
 
 
-ENTRYPOINT ["/bin/bash"]
 
+ENTRYPOINT ["/bin/bash"]

--- a/image_classification/tensorflow/README.md
+++ b/image_classification/tensorflow/README.md
@@ -4,7 +4,7 @@ Install
 In order to run this, you must first set stuff up... for now see Transformer's README.
 
 
-Downlaoding Data
+Downloading Data
 ==========
 
 Downloading data is TBD.
@@ -19,7 +19,9 @@ TBD.
 Running the Benchmark
 ============
 
-You first must build the docker file;
+You must first download nccl-repo-ubuntu1604-2.5.6-ga-cuda9.0_1-1_amd64.deb from https://developer.nvidia.com/nccl, and move it into the same directory as this README.
+ 
+You must then build the docker file;
 
     docker build .
 
@@ -31,7 +33,7 @@ Remember the image name/number.
 2. Choose your random seed (below we use 77)
 3. Enter your docker's image name (below we use 5ca81979cbc2 which you don't have)
 
-Then, executute the following:
+Then, execute the following:
 
     sudo docker run -v /imn:/imn --runtime=nvidia -t -i 5ca81979cbc2 "./run_and_time.sh" 77 | tee benchmark.log
 

--- a/image_classification/tensorflow/official/requirements.txt
+++ b/image_classification/tensorflow/official/requirements.txt
@@ -1,3 +1,4 @@
 psutil>=5.4.3
 py-cpuinfo>=3.3.0
 google-cloud-bigquery>=0.31.0
+mlperf_compliance==0.0.6

--- a/image_classification/tensorflow/official/resnet/resnet_run_loop.py
+++ b/image_classification/tensorflow/official/resnet/resnet_run_loop.py
@@ -367,8 +367,7 @@ def resnet_model_fn(features, labels, mode, model_class,
 
       # Once the gradient computation is complete we can scale the gradients
       # back to the correct scale before passing them to the optimizer.
-      unscaled_grad_vars = [(grad / loss_scale, var)
-                            for grad, var in scaled_grad_vars]
+      unscaled_grad_vars = [(grad / loss_scale, var) if grad is not None else (grad, var) for grad, var in scaled_grad_vars]
       minimize_op = optimizer.apply_gradients(unscaled_grad_vars, global_step)
     else:
       minimize_op = optimizer.minimize(loss, global_step)


### PR DESCRIPTION
I faced multiple errors while trying to build an image from the existing Dockerfile for image classification.

First, I faced “RuntimeError: Python version >= 3.7 required.”, as the latest versions of numpy and scipy require Python >=3.7.

I changed the numpy and scipy versions accordingly and tried tensorflow-gpu 1.12.0, but faced an issue similar to https://github.com/tensorflow/tensorflow/issues/16478, so I added futures==3.1.1 to the Dockerfile because of that. I had to use tensorflow-gpu 1.10.0 instead of tensorflow-gpu 1.12.0, in order to fix https://github.com/mlcommons/training/issues/204.

I also faced https://bbs.archlinux.org/viewtopic.php?id=261412, which is why I added h5py==2.10.0 in the Dockerfile.

official/requirements.txt was missing the line mlperf_compliance==0.0.6, so I had to add it there.

After successfully building the Docker image, I faced https://github.com/mlcommons/training/issues/223, and followed the suggested solution in the thread to fix the issue.

Finally, I had to download nccl2 manually because the runtime image didn't seem to support nccl2.

After making these changes, I was able to start the run successfully.
