### PR TITLE
[RNN-T] bucketing sampler fix

### DIFF
--- a/rnn_speech_recognition/pytorch/common/data/dali/sampler.py
+++ b/rnn_speech_recognition/pytorch/common/data/dali/sampler.py
@@ -81,7 +81,7 @@ class BucketingSampler(SimpleSampler):
         epochs = np.reshape(shuffled_buckets, [self.num_epochs, -1])
         to_drop = epochs.shape[1] - (epochs.shape[1] // gbs * gbs)
         for epoch in epochs:
-            dropped_idxs = self.rng.choice(epochs.shape[1], to_drop)
+            dropped_idxs = self.rng.choice(epochs.shape[1], to_drop, replace=False)
             if dropped_idxs is not None:
                 epoch[dropped_idxs] = -1
         epochs = epochs[epochs != -1].reshape(self.num_epochs, -1)

--- a/rnn_speech_recognition/pytorch/common/data/dali/sampler.py
+++ b/rnn_speech_recognition/pytorch/common/data/dali/sampler.py
@@ -83,8 +83,8 @@ class BucketingSampler(SimpleSampler):
         for epoch in epochs:
             dropped_idxs = self.rng.choice(epochs.shape[1], to_drop)
             if dropped_idxs is not None:
-                epoch[dropped_idxs] = epoch[-to_drop:]
-        epochs = epochs[:, :epochs.shape[1] // gbs * gbs]
+                epoch[dropped_idxs] = -1
+        epochs = epochs[epochs != -1].reshape(self.num_epochs, -1)
         self.dataset_size = epochs.shape[1]
 
         epochs_iters_batch = np.reshape(epochs, [self.num_epochs, -1, gbs])


### PR DESCRIPTION
The bucket sampling algorithm described in the [README](https://github.com/mlcommons/training/blob/8f7f74f88874ae85a58ddedd778c320739b37444/rnn_speech_recognition/pytorch/README.md#training-data-order) removes random samples from epoch to make epoch divisible by the batch size (point 4.ii).

Source has a bug, where the samples are not removed, but replaced by samples from the last bucket, that contains the longest samples:https://github.com/mlcommons/training/blob/8f7f74f88874ae85a58ddedd778c320739b37444/rnn_speech_recognition/pytorch/common/data/dali/sampler.py#L86

The bug has two impacts:
1. A negative impact on performance, as the longes samples are mixed with shorter samples. As result, more padding is needed.
2. It impacts sample randomness, as the longest samples are chosen more often.

This PR aligns code to the algorithm described in the README.
An alternative solution is to update the README, and submitters would need to follow the bugged algorithm.