### PR TITLE
Add MLCube support for Object Detection Benchmark

### DIFF
--- a/object_detection/.dockerignore
+++ b/object_detection/.dockerignore
@@ -1,0 +1,2 @@
+# Do not add MLCube's workspace directory.
+mlcube/

--- a/object_detection/.gitignore
+++ b/object_detection/.gitignore
@@ -1,0 +1,1 @@
+mlcube/workspace/data

--- a/object_detection/Dockerfile.mlcube
+++ b/object_detection/Dockerfile.mlcube
@@ -1,0 +1,31 @@
+FROM pytorch/pytorch:1.6.0-cuda10.1-cudnn7-devel
+
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
+# install basics
+RUN apt-get update -y \
+ && apt-get install -y apt-utils curl unzip pv \
+                       libglib2.0-0=2.56.1-2ubuntu1 \
+                       libsm6=2:1.2.2-1 \
+                       libxext6=2:1.3.3-1 \
+                       libxrender-dev=1:0.9.10-1
+
+RUN pip install ninja==1.8.2.post2 \
+                yacs==0.1.5 \
+                cython==0.29.5 \
+                matplotlib==3.0.2 \
+                opencv-python==4.0.0.21 \
+                mlperf_compliance==0.0.10 \
+                torchvision==0.2.2 \
+                pycocotools==2.0.2 \
+                typer==0.3.2
+
+RUN pip install --no-cache-dir https://github.com/mlperf/logging/archive/9ea0afa.zip
+
+WORKDIR /workspace
+
+COPY . .
+
+RUN chmod +x ./run_and_time.sh ./download_dataset.sh
+
+ENTRYPOINT ["python", "/workspace/mlcube.py"]

--- a/object_detection/README_OLD.md
+++ b/object_detection/README_OLD.md
@@ -1,0 +1,95 @@
+# 1. Problem
+Object detection and segmentation. Metrics are mask and box mAP.
+
+# 2. Directions
+
+### Steps to configure machine
+
+1. Checkout the MLPerf repository
+```
+mkdir -p mlperf
+cd mlperf
+git clone https://github.com/mlperf/training.git
+```
+2. Install CUDA and Docker
+```
+source training/install_cuda_docker.sh
+```
+3. Build the docker image for the object detection task
+```
+cd training/object_detection/
+nvidia-docker build . -t mlperf/object_detection
+```
+
+4. Run docker container and install code
+```
+nvidia-docker run -v .:/workspace -t -i --rm --ipc=host mlperf/object_detection \
+    "cd mlperf/training/object_detection && ./install.sh"
+```
+Now exit the docker container (Ctrl-D) to get back to your host.
+
+### Steps to download data
+```
+# From training/object_detection/
+source download_dataset.sh
+```
+
+### Steps to run benchmark.
+```
+nvidia-docker run -v .:/workspace -t -i --rm --ipc=host mlperf/object_detection \
+    "cd mlperf/training/object_detection && ./run_and_time.sh"
+```
+
+# 3. Dataset/Environment
+### Publication/Attribution
+Microsoft COCO: Common Objects in Context
+
+### Data preprocessing
+Only horizontal flips are allowed.
+
+### Training and test data separation
+As provided by MS-COCO (2017 version).
+
+### Training data order
+Randomly.
+
+### Test data order
+Any order.
+
+# 4. Model
+### Publication/Attribution
+He, Kaiming, et al. "Mask r-cnn." Computer Vision (ICCV), 2017 IEEE International Conference on.
+IEEE, 2017.
+
+We use a version of Mask R-CNN with a ResNet50 backbone.
+
+### List of layers
+Running the timing script will display a list of layers.
+
+### Weight and bias initialization
+The ResNet50 base must be loaded from the provided weights. They may be quantized.
+
+### Loss function
+Multi-task loss (classification, box, mask). Described in the Mask R-CNN paper.
+
+Classification: Smooth L1 loss
+
+Box: Log loss for true class.
+
+Mask: per-pixel sigmoid, average binary cross-entropy loss.
+
+### Optimizer
+Momentum SGD. Weight decay of 0.0001, momentum of 0.9.
+
+# 5. Quality
+### Quality metric
+As Mask R-CNN can provide both boxes and masks, we evaluate on both box and mask mAP.
+
+### Quality target
+Box mAP of 0.377, mask mAP of 0.339
+
+### Evaluation frequency
+Once per epoch, 118k.
+
+### Evaluation thoroughness
+Evaluate over the entire validation set. Use the official COCO API to compute mAP.

--- a/object_detection/download_dataset.sh
+++ b/object_detection/download_dataset.sh
@@ -1,20 +1,29 @@
 #!/bin/bash
 
 # Get COCO 2017 data sets
-mkdir -p pytorch/datasets/coco
-pushd pytorch/datasets/coco
+DATA_ROOT_DIR="${DATA_ROOT_DIR:-./pytorch/datasets/coco}"
+echo "Downloaading to folder: $DATA_ROOT_DIR"
+mkdir -p $DATA_ROOT_DIR
+pushd $DATA_ROOT_DIR
 
 curl -O https://dl.fbaipublicfiles.com/detectron/coco/coco_annotations_minival.tgz
-tar xzf coco_annotations_minival.tgz
-
-curl -O http://images.cocodataset.org/zips/train2017.zip
-unzip train2017.zip
-
-curl -O http://images.cocodataset.org/zips/val2017.zip
-unzip val2017.zip
+echo "Extracting coco_annotations_minival.tgz ..."
+tar -xzf coco_annotations_minival.tgz &>/dev/null
 
 curl -O http://images.cocodataset.org/annotations/annotations_trainval2017.zip
-unzip annotations_trainval2017.zip
+echo "Extracting annotations_trainval2017.zip ..."
+n_files=`unzip -l  annotations_trainval2017.zip| grep .json | wc -l`
+unzip annotations_trainval2017.zip | pv -l -s $n_files > /dev/null
+
+curl -O http://images.cocodataset.org/zips/val2017.zip
+echo "Extracting val2017.zip ..."
+n_files=`unzip -l  val2017.zip| grep .jpg | wc -l`
+unzip val2017.zip | pv -l -s $n_files > /dev/null
+
+curl -O http://images.cocodataset.org/zips/train2017.zip
+echo "Extracting train2017.zip ..."
+n_files=`unzip -l  train2017.zip| grep .jpg | wc -l`
+unzip train2017.zip | pv -l -s $n_files > /dev/null
 
 # TBD: MD5 verification
 # $md5sum *.zip *.tgz

--- a/object_detection/mlcube.py
+++ b/object_detection/mlcube.py
@@ -1,0 +1,62 @@
+"""MLCube handler file"""
+import os
+import yaml
+import typer
+import shutil
+import subprocess
+from pathlib import Path
+
+
+app = typer.Typer()
+
+class DownloadDataTask(object):
+    """Download task Class
+    It defines the environment variables:
+        DATA_ROOT_DIR: Directory path to download the dataset
+    Then executes the download script"""
+    @staticmethod
+    def run(data_dir: str) -> None:
+
+        env = os.environ.copy()
+        env.update({
+            'DATA_ROOT_DIR': data_dir,
+        })
+
+        process = subprocess.Popen("./download_dataset.sh", cwd=".", env=env)
+        process.wait()
+
+class TrainTask(object):
+    """Preprocess dataset task Class
+    It defines the environment variables:
+        DATA_DIR: Dataset directory path
+        OUTPUT_DIR: Directory path where model will be saved
+        All other parameters defined in parameters_file
+    Then executes the benchmark script"""
+    @staticmethod
+    def run(data_dir: str, output_dir: str, parameters_file: str) -> None:
+        with open(parameters_file, 'r') as stream:
+            parameters = yaml.safe_load(stream)
+
+        env = os.environ.copy()
+        env.update({
+            'DATA_DIR': data_dir,
+            'OUTPUT_DIR': output_dir,
+        })
+
+        env.update(parameters)
+
+        process = subprocess.Popen("./run_and_time.sh", cwd=".", env=env)
+        process.wait()
+
+@app.command("download_data")
+def download_data(data_dir: str = typer.Option(..., '--data_dir')):
+    DownloadDataTask.run(data_dir)
+
+@app.command("train")
+def train(data_dir: str = typer.Option(..., '--data_dir'),
+          output_dir: str = typer.Option(..., '--output_dir'),
+          parameters_file: str = typer.Option(..., '--parameters_file')):
+    TrainTask.run(data_dir, output_dir, parameters_file)
+
+if __name__ == '__main__':
+    app()

--- a/object_detection/mlcube/mlcube.yaml
+++ b/object_detection/mlcube/mlcube.yaml
@@ -1,0 +1,32 @@
+name: Object Detection
+description: MLCommons Object Detection Training Reference Benchmark
+authors: 
+ - {name: "MLCommons Best Practices Working Group"}
+
+platform:
+  # Edit this according to your system specs
+  accelerator_count: 1
+
+container:
+  # Image name.
+  image: mlcommons/object_detection:0.0.1
+  # Docker build context relative to $MLCUBE_ROOT. Default is `build`.
+  build_context: "../"
+  # Docker file name within docker build context, default is `Dockerfile`.
+  build_file: "Dockerfile.mlcube"
+
+tasks:
+  # Download LibriSpeech dataset
+  download_data:
+    io:
+      # Directory for uncompressed datasets. Total size is ~ 65G.
+      - {name: data_dir, type: directory, io: output, default: $WORKSPACE/data}
+  train:
+  # Train Object Detection model
+    io:
+      # see Download::data_dir, it takes the processes subfolder
+      - {name: data_dir, type: directory, io: input, default: $WORKSPACE/data/LibriSpeech}
+      # Model output folder
+      - {name: output_dir, type: directory, io: output, default: $WORKSPACE/output}
+      # Yaml file with training parameters.
+      - {name: parameters_file, type: file, io: input, default: $WORKSPACE/parameters.yaml}

--- a/object_detection/mlcube/mlcube_cli.py
+++ b/object_detection/mlcube/mlcube_cli.py
@@ -1,0 +1,70 @@
+"""
+This requires the MLCube 2.0 configuration
+"""
+import os
+import yaml
+import click
+import typing
+from mlcube_docker.docker_run import DockerRun
+
+
+def load_config(mlcube_config_path: str, user_config_path: str) -> typing.Dict:
+    """Returns dictionary containing MLCube configuration"""
+    # Load mlcube config data
+    try:
+        with open(mlcube_config_path) as stream:
+            mlcube_config_data = yaml.load(stream.read(), Loader=yaml.SafeLoader)
+    except IOError as exc:
+        # If file doesn't exist throw the exception:
+        # OSError: {PATH_TO}/mnist/mlcube.yaml: No such file or directory
+        raise IOError("%s: %s" % (mlcube_config_path, exc.strerror))
+
+    # Load user config data if file exists
+    if os.path.isfile(user_config_path):
+        with open(user_config_path) as stream:
+            user_config_data = yaml.load(stream.read(), Loader=yaml.SafeLoader)
+    else:
+        return mlcube_config_data
+
+    # Merge config data
+    tmp = mlcube_config_data['container']
+    mlcube_config_data['container'] = user_config_data['container']
+    mlcube_config_data['container'].update(tmp)
+    return mlcube_config_data
+
+
+@click.group(name='mlcube')
+def cli():
+    pass
+
+
+@cli.command(name='run', help='Run MLCube ML task.',
+             context_settings=dict(ignore_unknown_options=True, allow_extra_args=True))
+@click.option('--mlcube', required=False, type=str, help='Path to MLCube directory, default is current.')
+@click.option('--platform', required=False, type=str, help='Platform to run MLCube, default is docker/podman.')
+@click.option('--task', required=False, type=str, help='MLCube task name to run, default is `main`.')
+@click.option('--workspace', required=False, type=str, help='Workspace path, default is `workspace` within '
+                                                            'MLCube folder')
+def run(mlcube: str, platform: str, task: str, workspace: str):
+    mlcube_root = os.path.abspath(mlcube or os.getcwd())
+    if os.path.isfile(mlcube_root):
+        mlcube_root = os.path.dirname(mlcube_root)
+
+    platform = platform or 'docker'
+    if platform != 'docker':
+        raise ValueError(f"Only `docker` platform is supported")
+
+    task = task or 'main'
+    workspace = workspace or os.path.join(mlcube_root, 'workspace')
+
+    mlcube_config_data = load_config(
+        os.path.join(str(mlcube_root), 'mlcube.yaml'),
+        os.path.join(os.path.expanduser("~"), '.mlcube.yaml')
+    )
+
+    docker_runner = DockerRun(mlcube_config_data, root=mlcube_root, workspace=workspace, task=task)
+    docker_runner.run()
+
+
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
## Current implementation

We'll be updating this section as we merge MLCube PRs and make new MLCube releases.

### Project setup
```Python
# Create Python environment 
virtualenv -p python3 ./env && source ./env/bin/activate

# Install MLCube and MLCube docker runner from GitHub repository (normally, users will just run `pip install mlcube mlcube_docker`)
git clone https://github.com/sergey-serebryakov/mlbox.git && cd mlbox && git checkout feature/configV2
cd ./runners/mlcube_docker && export PYTHONPATH=$(pwd)
cd ../../ && pip install -r mlcube/requirements.txt && pip install omegaconf && cd ../

# Fetch the RNN speech recognition workload
git clone https://github.com/mlcommons/training && cd ./training
git fetch origin pull/491/head:feature/object_detection && git checkout feature/object_detection
cd ./object_detection/mlcube
```

### Dataset


The COCO dataset will be downloaded and extracted. Sizes of the dataset in each step:

| Dataset Step                   | MLCube Task       | Format         | Size     |
|--------------------------------|-------------------|----------------|----------|
| Download (Compressed dataset)  | download_data     | Tar/Zip files  | ~20.5 GB |
| Extract (Uncompressed dataset) | download_data     | Jpg/Json files | ~21.2 GB |
| Total                          | (After all tasks) | All            | ~41.7 GB |

### Tasks execution
```
# Download COCO dataset. Default path = /workspace/data
# To override it, use --data_dir=DATA_DIR
python mlcube_cli.py run --task download_data --platform docker

# Run benchmark.
 TODO
```