### PR TITLE
MLCube packing: Bert benchmark [WIP]

### DIFF
--- a/language_model/tensorflow/.gitignore
+++ b/language_model/tensorflow/.gitignore
@@ -1,0 +1,1 @@
+workspace/data/

--- a/language_model/tensorflow/bert/Dockerfile
+++ b/language_model/tensorflow/bert/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     build-essential \
+    bzip2 \
     python3 \
     python3-pip \
     python3-setuptools

--- a/language_model/tensorflow/bert/Dockerfile
+++ b/language_model/tensorflow/bert/Dockerfile
@@ -1,22 +1,14 @@
 #FROM nvidia/cuda:9.0-cudnn7-runtime-ubuntu16.04
-FROM ubuntu:18.04
+FROM tensorflow/tensorflow:1.15.2-gpu
 
 RUN apt-get update
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     build-essential \
     git \
-    bzip2 \
-    python3 \
-    python3-pip \
-    python3-setuptools
-
-ENV LC_ALL=C.UTF-8
-ENV LANG=C.UTF-8
+    bzip2 
 
 COPY requirements.txt /requirements.txt
-RUN ln -s /usr/bin/python3 /usr/bin/python & \
-    ln -s /usr/bin/pip3 /usr/bin/pip
 RUN pip install --no-cache-dir -r /requirements.txt
 
 COPY . /workspace

--- a/language_model/tensorflow/bert/Dockerfile
+++ b/language_model/tensorflow/bert/Dockerfile
@@ -1,0 +1,20 @@
+#FROM nvidia/cuda:9.0-cudnn7-runtime-ubuntu16.04
+FROM ubuntu:18.04
+
+RUN apt-get update
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    build-essential \
+    python3 \
+    python3-pip \
+    python3-setuptools
+
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+
+COPY requirements.txt /requirements.txt
+RUN pip3 install --no-cache-dir -r /requirements.txt
+
+COPY . /workspace
+WORKDIR /workspace
+ENTRYPOINT ["python3", "mlcube.py"]

--- a/language_model/tensorflow/bert/Dockerfile
+++ b/language_model/tensorflow/bert/Dockerfile
@@ -15,8 +15,10 @@ ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 
 COPY requirements.txt /requirements.txt
-RUN pip3 install --no-cache-dir -r /requirements.txt
+RUN ln -s /usr/bin/python3 /usr/bin/python & \
+    ln -s /usr/bin/pip3 /usr/bin/pip
+RUN pip install --no-cache-dir -r /requirements.txt
 
 COPY . /workspace
 WORKDIR /workspace
-ENTRYPOINT ["python3", "mlcube.py"]
+ENTRYPOINT ["python", "mlcube.py"]

--- a/language_model/tensorflow/bert/Dockerfile
+++ b/language_model/tensorflow/bert/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     build-essential \
+    git \
     bzip2 \
     python3 \
     python3-pip \

--- a/language_model/tensorflow/bert/cleanup_scripts/download_and_uncompress.sh
+++ b/language_model/tensorflow/bert/cleanup_scripts/download_and_uncompress.sh
@@ -2,11 +2,10 @@
 
 pip install --user gdown
 
-data_dir="${DATA_DIR:-./wiki}"
+data_dir=${DATA_DIR:-./}
+mkdir -p $data_dir/wiki
 
-mkdir -p $data_dir
-
-cd $data_dir
+cd $data_dir/wiki
 
 # Downloading files from Google Drive location: https://drive.google.com/drive/folders/1oQF4diVHNPCclykwdvQJw8n_VIWwV0PT
 
@@ -53,6 +52,3 @@ gdown https://drive.google.com/uc?id=1oVBgtSxkXC9rH2SXJv85RXR9-WrMPy-Q
 
 # Back to bert/cleanup_scripts
 cd ../..
-
-
-

--- a/language_model/tensorflow/bert/cleanup_scripts/download_and_uncompress.sh
+++ b/language_model/tensorflow/bert/cleanup_scripts/download_and_uncompress.sh
@@ -2,9 +2,11 @@
 
 pip install --user gdown
 
-mkdir -p wiki
+data_dir="${DATA_DIR:-./wiki}"
 
-cd wiki
+mkdir -p $data_dir
+
+cd $data_dir
 
 # Downloading files from Google Drive location: https://drive.google.com/drive/folders/1oQF4diVHNPCclykwdvQJw8n_VIWwV0PT
 

--- a/language_model/tensorflow/bert/cleanup_scripts/download_and_uncompress.sh
+++ b/language_model/tensorflow/bert/cleanup_scripts/download_and_uncompress.sh
@@ -24,6 +24,8 @@ gdown https://drive.google.com/uc?id=14_A6gQ0NJ7Pay1X0xFq9rCKUuFJcKLF-
 # enwiki-20200101-pages-articles-multistream.xml.bz2
 gdown https://drive.google.com/uc?id=18K1rrNJ_0lSR9bsLaoP3PkQeSFO-9LE7
 
+echo uncompressing enwiki-20200101-pages-articles-multistream.xml.bz2
+echo this may take a while...
 bzip2 -d enwiki-20200101-pages-articles-multistream.xml.bz2
 
 # Download TF-1 checkpoints

--- a/language_model/tensorflow/bert/cleanup_scripts/generate_tfrecords.sh
+++ b/language_model/tensorflow/bert/cleanup_scripts/generate_tfrecords.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+data_dir=${DATA_DIR:-./}
+wiki_dir=$data_dir/wiki/
+results_dir=$data_dir/results/
+tfrecord_dir=$data_dir/tfrecord/
+
+mkdir -p $tfrecord_dir
+
+echo "Processing train data"
+python create_pretraining_data.py \
+   --input_file=$results_dir/part-00XXX-of-00500 \
+   --output_file=$tfrecord_dir/part-00XXX-of-00500 \
+   --vocab_file=$wiki_dir/vocab.txt \
+   --do_lower_case=True \
+   --max_seq_length=512 \
+   --max_predictions_per_seq=76 \
+   --masked_lm_prob=0.15 \
+   --random_seed=12345 \
+   --dupe_factor=10
+
+echo "Processing eval data"
+python create_pretraining_data.py \
+  --input_file=$results_dir/eval.txt \
+  --output_file=$tfrecord_dir/eval_intermediate \
+  --vocab_file=$wiki_dir/vocab.txt \
+  --do_lower_case=True \
+  --max_seq_length=512 \
+  --max_predictions_per_seq=76 \
+  --masked_lm_prob=0.15 \
+  --random_seed=12345 \
+  --dupe_factor=10
+
+python3 pick_eval_samples.py \
+  --input_tfrecord=$tfrecord_dir/eval_intermediate \
+  --output_tfrecord=$tfrecord_dir/eval_10k \
+  --num_examples_to_pick=10000

--- a/language_model/tensorflow/bert/cleanup_scripts/process_wiki.sh
+++ b/language_model/tensorflow/bert/cleanup_scripts/process_wiki.sh
@@ -5,29 +5,39 @@
 # example: ./process_wiki.sh 'sample_data/wiki_??'
 # The resulted files will be placed in ./results
 
-inputs=$1
+data_dir=${DATA_DIR:-./}
+text_dir=$data_dir/text/
+inputs="${text_dir}*/wiki_??"
+
+ls $inputs
 
 pip install nltk==3.4.5
 
 # Remove doc tag and title
+echo "RUNNING SCRIPT #1: cleanup_file.py"
 python ./cleanup_file.py --data=$inputs --output_suffix='.1'
 
 # Further clean up files
+echo "RUNNING SCRIPT #2: clean.sh"
 for f in ${inputs}; do
   ./clean.sh ${f}.1 ${f}.2
 done
 
 # Sentence segmentation
+echo "RUNNING SCRIPT #3: do_sentence_segmentation.py"
 python ./do_sentence_segmentation.py --data=$inputs --input_suffix='.2' --output_suffix='.3'
 
-mkdir -p ./results
+result_dir=$data_dir/results
+mkdir -p $result_dir
 
 # Train/Eval seperation
-python ./seperate_test_set.py --data=$inputs --input_suffix='.3' --output_suffix='.4' --num_test_articles=10000 --test_output='./results/eval'
+echo "RUNNING SCRIPT #4: seperate_test_set.py"
+python ./seperate_test_set.py --data=$inputs --input_suffix='.3' --output_suffix='.4' --num_test_articles=10000 --test_output="${result_dir}/eval"
 
 ## Choose file size method or number of packages by uncommenting only one of the following do_gather options
 # Gather into fixed size packages
-python ./do_gather.py --data=$inputs --input_suffix='.4' --block_size=26.92 --out_dir='./results'
+echo "RUNNING SCRIPT #5: do_gather.py"
+python ./do_gather.py --data=$inputs --input_suffix='.4' --block_size=26.92 --out_dir=$result_dir
 
 # Gather into fixed number of packages
 #NUM_PACKAGES=512

--- a/language_model/tensorflow/bert/cleanup_scripts/run_wiki_extractor.sh
+++ b/language_model/tensorflow/bert/cleanup_scripts/run_wiki_extractor.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+git clone https://github.com/attardi/wikiextractor.git
+
+cd wikiextractor
+
+git checkout 3162bb6c3c9ebd2d15be507aa11d6fa818a454ac
+
+# Back to <bert>/cleanup_scripts
+cd .. 
+
+# Run `WikiExtractor.py` to extract data from XML.
+data_dir=${DATA_DIR:-./wiki}
+python3 wikiextractor/WikiExtractor.py $data_dir/enwiki-20200101-pages-articles-multistream.xml -o $data_dir/text

--- a/language_model/tensorflow/bert/cleanup_scripts/run_wiki_extractor.sh
+++ b/language_model/tensorflow/bert/cleanup_scripts/run_wiki_extractor.sh
@@ -10,5 +10,6 @@ git checkout 3162bb6c3c9ebd2d15be507aa11d6fa818a454ac
 cd .. 
 
 # Run `WikiExtractor.py` to extract data from XML.
-data_dir=${DATA_DIR:-./wiki}
-python3 wikiextractor/WikiExtractor.py $data_dir/enwiki-20200101-pages-articles-multistream.xml -o $data_dir/text
+data_dir=${DATA_DIR:-./}
+wiki_dir=$data_dir/wiki
+python wikiextractor/WikiExtractor.py $wiki_dir/enwiki-20200101-pages-articles-multistream.xml -o $data_dir/text

--- a/language_model/tensorflow/bert/mlcube.py
+++ b/language_model/tensorflow/bert/mlcube.py
@@ -58,9 +58,25 @@ class PreprocessTask(object):
         env.update({
             'DATA_DIR': data_dir,
         })
-        print("PREPROCESSING")
         process = subprocess.Popen(
             "./process_wiki.sh", cwd="./cleanup_scripts", env=env)
+        process.wait()
+
+
+class GenerateTfrecordsTask(object):
+    """Preprocess task Class
+    It defines the environment variables:
+        DATA_ROOT_DIR: Directory path to download the dataset
+    Then executes the download script"""
+    @staticmethod
+    def run(data_dir: str) -> None:
+
+        env = os.environ.copy()
+        env.update({
+            'DATA_DIR': data_dir,
+        })
+        process = subprocess.Popen(
+            "./generate_tfrecords.sh", cwd="./cleanup_scripts", env=env)
         process.wait()
 
 
@@ -93,9 +109,9 @@ def preprocess(data_dir: str = typer.Option(..., '--data_dir')):
     PreprocessTask.run(data_dir)
 
 
-@app.command("preprocess_data")
-def preprocess(data_dir: str = typer.Option(..., '--data_dir')):
-    PreprocessTask.run(data_dir)
+@app.command("generate_tfrecords")
+def generate_tfrecords(data_dir: str = typer.Option(..., '--data_dir')):
+    GenerateTfrecordsTask.run(data_dir)
 
 
 @app.command("train")

--- a/language_model/tensorflow/bert/mlcube.py
+++ b/language_model/tensorflow/bert/mlcube.py
@@ -1,0 +1,65 @@
+"""MLCube handler file"""
+import os
+import yaml
+import typer
+import shutil
+import subprocess
+from pathlib import Path
+
+
+app = typer.Typer()
+
+class DownloadTask(object):
+    """Download task Class
+    It defines the environment variables:
+        DATA_ROOT_DIR: Directory path to download the dataset
+    Then executes the download script"""
+    @staticmethod
+    def run(data_dir: str) -> None:
+
+        env = os.environ.copy()
+        env.update({
+            'DATA_DIR': data_dir,
+        })
+
+        process = subprocess.Popen("./cleanup_scripts/download_and_uncompress.sh", cwd=".", env=env)
+        process.wait()
+
+class PreprocessTask(object):
+    """Preprocess dataset task Class
+    It defines the environment variables:
+        DATA_ROOT_DIR: Dataset directory path
+    Then executes the preprocess script"""
+    @staticmethod
+    def run(data_dir: str) -> None:
+
+        pass
+
+class TrainTask(object):
+    """Preprocess dataset task Class
+    It defines the environment variables:
+        DATA_DIR: Dataset directory path
+        All other parameters are defined in the parameters_file
+    Then executes the benchmark script"""
+    @staticmethod
+    def run(dataset_file_path: str, parameters_file: str) -> None:
+        with open(parameters_file, 'r') as stream:
+            parameters = yaml.safe_load(stream)
+
+        pass
+
+@app.command("download")
+def download(data_dir: str = typer.Option(..., '--data_dir')):
+    DownloadTask.run(data_dir)
+
+@app.command("preprocess_data")
+def preprocess(data_dir: str = typer.Option(..., '--data_dir')):
+    PreprocessTask.run(data_dir)
+
+@app.command("train")
+def train(dataset_file_path: str = typer.Option(..., '--dataset_file_path'),
+          parameters_file: str = typer.Option(..., '--parameters_file')):
+    TrainTask.run(dataset_file_path, parameters_file)
+
+if __name__ == '__main__':
+    app()

--- a/language_model/tensorflow/bert/mlcube.py
+++ b/language_model/tensorflow/bert/mlcube.py
@@ -47,14 +47,21 @@ class ExtractTask(object):
 
 
 class PreprocessTask(object):
-    """Preprocess dataset task Class
+    """Preprocess task Class
     It defines the environment variables:
-        DATA_ROOT_DIR: Dataset directory path
-    Then executes the preprocess script"""
+        DATA_ROOT_DIR: Directory path to download the dataset
+    Then executes the download script"""
     @staticmethod
     def run(data_dir: str) -> None:
 
-        pass
+        env = os.environ.copy()
+        env.update({
+            'DATA_DIR': data_dir,
+        })
+        print("PREPROCESSING")
+        process = subprocess.Popen(
+            "./process_wiki.sh", cwd="./cleanup_scripts", env=env)
+        process.wait()
 
 
 class TrainTask(object):
@@ -75,9 +82,15 @@ class TrainTask(object):
 def download(data_dir: str = typer.Option(..., '--data_dir')):
     DownloadTask.run(data_dir)
 
+
 @app.command("extract")
 def extract(data_dir: str = typer.Option(..., '--data_dir')):
     ExtractTask.run(data_dir)
+
+
+@app.command("preprocess")
+def preprocess(data_dir: str = typer.Option(..., '--data_dir')):
+    PreprocessTask.run(data_dir)
 
 
 @app.command("preprocess_data")

--- a/language_model/tensorflow/bert/mlcube.py
+++ b/language_model/tensorflow/bert/mlcube.py
@@ -1,13 +1,14 @@
 """MLCube handler file"""
 import os
-import yaml
-import typer
 import shutil
 import subprocess
 from pathlib import Path
 
+import typer
+import yaml
 
 app = typer.Typer()
+
 
 class DownloadTask(object):
     """Download task Class
@@ -22,8 +23,28 @@ class DownloadTask(object):
             'DATA_DIR': data_dir,
         })
 
-        process = subprocess.Popen("./cleanup_scripts/download_and_uncompress.sh", cwd=".", env=env)
+        process = subprocess.Popen(
+            "./cleanup_scripts/download_and_uncompress.sh", cwd=".", env=env)
         process.wait()
+
+
+class ExtractTask(object):
+    """Extract task Class
+    It defines the environment variables:
+        DATA_ROOT_DIR: Directory path to download the dataset
+    Then executes the download script"""
+    @staticmethod
+    def run(data_dir: str) -> None:
+
+        env = os.environ.copy()
+        env.update({
+            'DATA_DIR': data_dir,
+        })
+
+        process = subprocess.Popen(
+            "./cleanup_scripts/run_wiki_extractor.sh", cwd=".", env=env)
+        process.wait()
+
 
 class PreprocessTask(object):
     """Preprocess dataset task Class
@@ -34,6 +55,7 @@ class PreprocessTask(object):
     def run(data_dir: str) -> None:
 
         pass
+
 
 class TrainTask(object):
     """Preprocess dataset task Class
@@ -48,18 +70,26 @@ class TrainTask(object):
 
         pass
 
+
 @app.command("download")
 def download(data_dir: str = typer.Option(..., '--data_dir')):
     DownloadTask.run(data_dir)
+
+@app.command("extract")
+def extract(data_dir: str = typer.Option(..., '--data_dir')):
+    ExtractTask.run(data_dir)
+
 
 @app.command("preprocess_data")
 def preprocess(data_dir: str = typer.Option(..., '--data_dir')):
     PreprocessTask.run(data_dir)
 
+
 @app.command("train")
 def train(dataset_file_path: str = typer.Option(..., '--dataset_file_path'),
           parameters_file: str = typer.Option(..., '--parameters_file')):
     TrainTask.run(dataset_file_path, parameters_file)
+
 
 if __name__ == '__main__':
     app()

--- a/language_model/tensorflow/bert/requirements.txt
+++ b/language_model/tensorflow/bert/requirements.txt
@@ -1,0 +1,3 @@
+PyYAML==5.4.1
+typer==0.3.2
+gdown==3.3.1

--- a/language_model/tensorflow/bert/requirements.txt
+++ b/language_model/tensorflow/bert/requirements.txt
@@ -1,3 +1,4 @@
 PyYAML==5.4.1
 typer==0.3.2
 gdown==3.3.1
+wheel==0.37.0

--- a/language_model/tensorflow/mlcube.yaml
+++ b/language_model/tensorflow/mlcube.yaml
@@ -26,6 +26,10 @@ tasks:
   # Download mnist dataset
     parameters:
       inputs: {data_dir: data/}
+  generate_tfrecords:
+  # Download mnist dataset
+    parameters:
+      inputs: {data_dir: data/}
   train:
   # Train model
     parameters:

--- a/language_model/tensorflow/mlcube.yaml
+++ b/language_model/tensorflow/mlcube.yaml
@@ -7,7 +7,7 @@ platform:
 
 docker:
   # Image name.
-  image: mlcommons/bert_tensorflow:0.0.1
+  image: mlcommons/bert:0.0.1
   # Docker build context relative to $MLCUBE_ROOT. Default is `build`.
   build_context: "bert"
   # Docker file name within docker build context, default is `Dockerfile`.
@@ -18,6 +18,10 @@ tasks:
   # Download mnist dataset
     parameters:
       outputs: {data_dir: data/}
+  extract:
+  # Download mnist dataset
+    parameters:
+      inputs: {data_dir: data/wiki/}
   train:
   # Train model
     parameters:

--- a/language_model/tensorflow/mlcube.yaml
+++ b/language_model/tensorflow/mlcube.yaml
@@ -1,0 +1,30 @@
+name: MLCommons Bert Benchmark
+authors: 
+ - {name: "MLCommons Best Practices Working Group"}
+
+platform:
+  accelerator_count: 0
+
+docker:
+  # Image name.
+  image: mlcommons/bert_tensorflow:0.0.1
+  # Docker build context relative to $MLCUBE_ROOT. Default is `build`.
+  build_context: "bert"
+  # Docker file name within docker build context, default is `Dockerfile`.
+  build_file: "Dockerfile"
+
+tasks:
+  download:
+  # Download mnist dataset
+    parameters:
+      outputs: {data_dir: data/}
+  train:
+  # Train model
+    parameters:
+      inputs: {data_dir: data/, parameters_file: parameters/default.parameters.yaml, model_in: model/}
+      outputs: {log_dir: train_logs/, metrics: {type: file, default: metrics/train_metrics.json}, model_dir: model/}
+  evaluate:
+  # evaluate model
+    parameters:
+      inputs: {data_dir: data/, parameters_file: parameters/default.parameters.yaml, model_in: model/}
+      outputs: {log_dir: evaluate_logs/, metrics: {type: file, default: metrics/evaluate_metrics.json}}

--- a/language_model/tensorflow/mlcube.yaml
+++ b/language_model/tensorflow/mlcube.yaml
@@ -21,7 +21,11 @@ tasks:
   extract:
   # Download mnist dataset
     parameters:
-      inputs: {data_dir: data/wiki/}
+      inputs: {data_dir: data/}
+  preprocess:
+  # Download mnist dataset
+    parameters:
+      inputs: {data_dir: data/}
   train:
   # Train model
     parameters:


### PR DESCRIPTION
### Project setup
```Python
# Create Python environment 
virtualenv -p python3 ./env && source ./env/bin/activate

# Install MLCube and MLCube docker runner from GitHub repository (normally, users will just run `pip install mlcube mlcube_docker`)
git clone https://github.com/sergey-serebryakov/mlbox.git && cd mlbox && git checkout feature/configV2
cd ./mlcube && python setup.py bdist_wheel  && pip install --force-reinstall ./dist/mlcube-* && cd ..
cd ./runners/mlcube_docker && python setup.py bdist_wheel  && pip install --force-reinstall --no-deps ./dist/mlcube_docker-* && cd ../../..
```

## Clone Training repo and go to Bert root directory
```
git clone https://github.com/mlcommons/training.git && cd ./training
git fetch origin pull/XX/head:feature/bert_mlcube && git checkout feature/bert_mlcube
cd ./language_model/tensorflow
```

## Run Bert MLCube on a local machine with Docker runner

```bash
# Run Bert tasks: download, extract, preprocess, generate_tfrecords and train
mlcube run --task download
mlcube run --task extract
mlcube run --task preprocess
mlcube run --task generate_tfrecords
# TODO: mlcube run --task train
```

We are targeting pull-type installation, so MLCubes should be available on docker hub. If not, try this:

```bash
mlcube run ... -Pdocker.build_strategy=auto
```

Also, users can override the workspace directory by using:

```bash
mlcube run --task=download --workspace=absolute_path_to_custom_dir
```