### PR TITLE
Improve memory usage of RNN-T encoder StackTime module

### DIFF
--- a/rnn_speech_recognition/pytorch/rnnt/model.py
+++ b/rnn_speech_recognition/pytorch/rnnt/model.py
@@ -42,9 +42,8 @@ class StackTime(nn.Module):
         s = r.shape
         rs = [s[0], s[1] // self.factor, s[2] * self.factor]
         r = torch.reshape(r, rs)
-        numer = x_lens + (self.factor * 2 - 1)
-        x_lens = torch.div(numer, self.factor, rounding_mode="trunc") - 1
         rt = torch.transpose(r, 0, 1)
+        x_lens = (x_lens.int() + self.factor - 1) // self.factor
         return rt, x_lens
 
 

--- a/rnn_speech_recognition/pytorch/rnnt/model.py
+++ b/rnn_speech_recognition/pytorch/rnnt/model.py
@@ -25,20 +25,27 @@ from common.rnn import rnn
 
 
 class StackTime(nn.Module):
+
+    __constants__ = ["factor"]
+
     def __init__(self, factor):
         super().__init__()
         self.factor = int(factor)
 
     def forward(self, x, x_lens):
         # T, B, U
-        seq = [x]
-        for i in range(1, self.factor):
-            tmp = torch.zeros_like(x)
-            tmp[:-i, :, :] = x[i:, :, :]
-            seq.append(tmp)
-        # x_lens = torch.ceil(x_lens.float() / self.factor).int()
-        x_lens = (x_lens.int() + self.factor - 1) // self.factor
-        return torch.cat(seq, dim=2)[::self.factor, :, :], x_lens
+        r = torch.transpose(x, 0, 1)
+        s = r.shape
+        zeros = torch.zeros(
+            s[0], (-s[1]) % self.factor, s[2], dtype=r.dtype, device=r.device)
+        r = torch.cat([r, zeros], 1)
+        s = r.shape
+        rs = [s[0], s[1] // self.factor, s[2] * self.factor]
+        r = torch.reshape(r, rs)
+        numer = x_lens + (self.factor * 2 - 1)
+        x_lens = torch.div(numer, self.factor, rounding_mode="trunc") - 1
+        rt = torch.transpose(r, 0, 1)
+        return rt, x_lens
 
 
 class RNNT(nn.Module):


### PR DESCRIPTION
The previous implementation of the RNN-T encoder StackTime module is slow and memory-inefficient. I have made a PR with this same fix to the MLCommons-Inference repo: https://github.com/mlcommons/inference/pull/1015