### PR TITLE
U-Net3D update for MLPerf 2.0

### DIFF
--- a/image_segmentation/pytorch/README.md
+++ b/image_segmentation/pytorch/README.md
@@ -86,7 +86,7 @@ bash run_and_time.sh <SEED>
 The script assumes that the data is available at `/data` directory.
 
 Running this command for seeds in range `{0, 1, ..., 9}` should converge to the target accuracy `mean_dice` = 0.908. 
-The training will be terminated once the quality threshold is reached or `MAX_EPOCH` (default: 4000) is surpassed. 
+The training will be terminated once the quality threshold is reached or the maximum number of epochs is surpassed. 
 If needed, those variables can be modified within the `run_and_time.sh` script.
 
 
@@ -133,20 +133,20 @@ The target `mean_dice` is 0.908.
 
 The evaluation schedule depends on the number of samples processed per epoch. Since the dataset is fairly small, and the
 global batch size respectively large, the last batch (padded or dropped) can represent a sizable fraction of the whole dataset.
-It is assumed that the last batch is always padded. Therefore, the evaluation schedule depends on the `samples per epoch` in the following manner:
+This implementation assumes that the last batch is always dropped. The evaluation schedule depends on the `samples per epoch` in the following manner:
 - for epochs 1 to CEILING(1000*168/`samples per epoch`) - 1: Do not evaluate
 - for epochs >= CEILING(1000\*168/`samples per epoch`): Evaluate every CEILING(20\*168/`samples per epoch`) epochs
 
 Two examples:
 1. Global batch size = 32:
-- `samples per epoch` = 192, since the last batch of 8 is padded to 32
-- evaluation starts at epoch = 875
-- evaluation is run every 18 epochs
+- `samples per epoch` = 160, since the last batch of 8 is dropped
+- evaluation starts at epoch = 1050
+- evaluation is run every 21 epochs
 
 2. Global batch size = 128:
-- `samples per epoch` = 256, since the last batch of 40 is padded to 64
-- evaluation starts at epoch = 657
-- evaluation is run every 14 epochs
+- `samples per epoch` = 128, since the last batch of 40 is dropped
+- evaluation starts at epoch = 1313
+- evaluation is run every 27 epochs
 
 The training should stop at epoch = CEILING(10000\*168/`samples per epoch`). If the model has not converged by that 
 epoch the run is considered as non-converged.

--- a/image_segmentation/pytorch/data_loading/data_loader.py
+++ b/image_segmentation/pytorch/data_loading/data_loader.py
@@ -3,13 +3,11 @@ import glob
 
 import numpy as np
 import torch
-from torch.utils.data import Dataset, DataLoader, RandomSampler
+from torch.utils.data import Dataset, DataLoader
 from torch.utils.data.distributed import DistributedSampler
 
 from data_loading.pytorch_loader import PytVal, PytTrain
 from runtime.logging import mllog_event
-
-DATASET_SIZE = 168
 
 
 def list_files_with_pattern(path, files_pattern):
@@ -30,7 +28,13 @@ def get_split(data, train_idx, val_idx):
     return train, val
 
 
-def get_data_split(path: str):
+def split_eval_data(x_val, y_val, num_shards, shard_id):
+    x = [a.tolist() for a in np.array_split(x_val, num_shards)]
+    y = [a.tolist() for a in np.array_split(y_val, num_shards)]
+    return x[shard_id], y[shard_id]
+
+
+def get_data_split(path: str, num_shards: int, shard_id: int):
     with open("evaluation_cases.txt", "r") as f:
         val_cases_list = f.readlines()
     val_cases_list = [case.rstrip("\n") for case in val_cases_list]
@@ -45,7 +49,9 @@ def get_data_split(path: str):
         else:
             imgs_train.append(case_img)
             lbls_train.append(case_lbl)
-    # print(f"Found {len(imgs_train)} Training cases, {len(imgs_val)} Validation cases.")
+    mllog_event(key='train_samples', value=len(imgs_train), sync=False)
+    mllog_event(key='eval_samples', value=len(imgs_val), sync=False)
+    imgs_val, lbls_val = split_eval_data(imgs_val, lbls_val, num_shards, shard_id)
     return imgs_train, imgs_val, lbls_train, lbls_val
 
 
@@ -70,31 +76,24 @@ class SyntheticDataset(Dataset):
         return self.x[idx % 32], self.y[idx % 32]
 
 
-def get_data_loaders(flags, num_shards):
+def get_data_loaders(flags, num_shards, global_rank):
     if flags.loader == "synthetic":
         train_dataset = SyntheticDataset(scalar=True, shape=flags.input_shape, layout=flags.layout)
         val_dataset = SyntheticDataset(scalar=True, shape=flags.val_input_shape, layout=flags.layout)
 
     elif flags.loader == "pytorch":
-        x_train, x_val, y_train, y_val = get_data_split(flags.data_dir)
+        x_train, x_val, y_train, y_val = get_data_split(flags.data_dir, num_shards, shard_id=global_rank)
         train_data_kwargs = {"patch_size": flags.input_shape, "oversampling": flags.oversampling, "seed": flags.seed}
         train_dataset = PytTrain(x_train, y_train, **train_data_kwargs)
         val_dataset = PytVal(x_val, y_val)
-        mllog_event(key='train_samples', value=len(x_train), sync=False)
-        mllog_event(key='eval_samples', value=len(x_val), sync=False)
     else:
         raise ValueError(f"Loader {flags.loader} unknown. Valid loaders are: synthetic, pytorch")
 
-    num_samples = DATASET_SIZE + (flags.batch_size * flags.ga_steps) - DATASET_SIZE % (flags.batch_size * flags.ga_steps) \
-        if DATASET_SIZE % (flags.batch_size * flags.ga_steps) > 0 else DATASET_SIZE
-    mllog_event(key='samples_per_epoch', value=num_samples, sync=False)
-    train_sampler = RandomSampler(train_dataset, replacement=True, num_samples=num_samples)
-    # train_sampler = DistributedSampler(train_dataset, seed=flags.seed, drop_last=False) if num_shards > 1 else None
-    # val_sampler = DistributedSampler(val_dataset, seed=flags.seed, drop_last=False) if num_shards > 1 else None
+    train_sampler = DistributedSampler(train_dataset, seed=flags.seed, drop_last=True) if num_shards > 1 else None
     val_sampler = None
 
     train_dataloader = DataLoader(train_dataset,
-                                  batch_size=flags.batch_size * flags.ga_steps,
+                                  batch_size=flags.batch_size,
                                   shuffle=not flags.benchmark and train_sampler is None,
                                   sampler=train_sampler,
                                   num_workers=flags.num_workers,

--- a/image_segmentation/pytorch/main.py
+++ b/image_segmentation/pytorch/main.py
@@ -1,4 +1,5 @@
 import os
+from math import ceil
 from mlperf_logging import mllog
 from mlperf_logging.mllog import constants
 
@@ -14,6 +15,8 @@ from runtime.distributed_utils import init_distributed, get_world_size, get_devi
 from runtime.distributed_utils import seed_everything, setup_seeds
 from runtime.logging import get_dllogger, mllog_start, mllog_end, mllog_event, mlperf_submission_log, mlperf_run_param_log
 from runtime.callbacks import get_callbacks
+
+DATASET_SIZE = 168
 
 
 def main():
@@ -45,7 +48,12 @@ def main():
 
     mllog_end(key=constants.INIT_STOP, sync=True)
     mllog_start(key=constants.RUN_START, sync=True)
-    train_dataloader, val_dataloader = get_data_loaders(flags, num_shards=world_size)
+    train_dataloader, val_dataloader = get_data_loaders(flags, num_shards=world_size, global_rank=local_rank)
+    samples_per_epoch = world_size * len(train_dataloader) * flags.batch_size
+    mllog_event(key='samples_per_epoch', value=samples_per_epoch, sync=False)
+    flags.evaluate_every = flags.evaluate_every or ceil(20*DATASET_SIZE/samples_per_epoch)
+    flags.start_eval_at = flags.start_eval_at or ceil(1000*DATASET_SIZE/samples_per_epoch)
+
     mllog_event(key=constants.GLOBAL_BATCH_SIZE, value=flags.batch_size * world_size * flags.ga_steps, sync=False)
     mllog_event(key=constants.GRADIENT_ACCUMULATION_STEPS, value=flags.ga_steps)
     loss_fn = DiceCELoss(to_onehot_y=True, use_softmax=True, layout=flags.layout,

--- a/image_segmentation/pytorch/requirements.txt
+++ b/image_segmentation/pytorch/requirements.txt
@@ -1,4 +1,4 @@
 git+https://github.com/NVIDIA/dllogger
-https://github.com/mlcommons/logging/archive/d08740cadb4188a5ebeb84ad6c68f98c1e129805.zip
+https://github.com/mlcommons/logging/archive/refs/tags/1.1.0-rc4.zip
 nibabel==3.2.1
 scipy==1.5.2

--- a/image_segmentation/pytorch/runtime/arguments.py
+++ b/image_segmentation/pytorch/runtime/arguments.py
@@ -33,8 +33,8 @@ PARSER.add_argument('--lr_decay_factor', dest='lr_decay_factor', type=float, def
 PARSER.add_argument('--lamb_betas', nargs='+', type=int, default=[0.9, 0.999])
 PARSER.add_argument('--momentum', dest='momentum', type=float, default=0.9)
 PARSER.add_argument('--weight_decay', dest='weight_decay', type=float, default=0.0)
-PARSER.add_argument('--evaluate_every', '--eval_every', dest='evaluate_every', type=int, default=20)
-PARSER.add_argument('--start_eval_at', dest='start_eval_at', type=int, default=1000)
+PARSER.add_argument('--evaluate_every', '--eval_every', dest='evaluate_every', type=int, default=None)
+PARSER.add_argument('--start_eval_at', dest='start_eval_at', type=int, default=None)
 PARSER.add_argument('--verbose', '-v', dest='verbose', action='store_true', default=False)
 PARSER.add_argument('--normalization', dest='normalization', type=str,
                     choices=['instancenorm', 'batchnorm'], default='instancenorm')

--- a/image_segmentation/pytorch/runtime/training.py
+++ b/image_segmentation/pytorch/runtime/training.py
@@ -50,7 +50,8 @@ def train(flags, model, train_loader, val_loader, loss_fn, score_fn, device, cal
                                                           device_ids=[flags.local_rank],
                                                           output_device=flags.local_rank)
 
-    stop_training = False
+    is_successful = False
+    diverged = False
     next_eval_at = flags.start_eval_at
     model.train()
     for callback in callbacks:
@@ -63,39 +64,35 @@ def train(flags, model, train_loader, val_loader, loss_fn, score_fn, device, cal
                     metadata={CONSTANTS.FIRST_EPOCH_NUM: epoch, CONSTANTS.EPOCH_COUNT: 1})
         mllog_start(key=CONSTANTS.EPOCH_START, metadata={CONSTANTS.EPOCH_NUM: epoch}, sync=False)
 
-        # if is_distributed:
-        #     train_loader.sampler.set_epoch(epoch)
-            # val_loader.sampler.set_epoch(epoch)
+        if is_distributed:
+            train_loader.sampler.set_epoch(epoch)
 
         loss_value = None
         optimizer.zero_grad()
         for iteration, batch in enumerate(tqdm(train_loader, disable=(rank != 0) or not flags.verbose)):
             image, label = batch
-            image = image.view(flags.ga_steps, flags.batch_size, 1, *flags.input_shape)
-            label = label.view(flags.ga_steps, flags.batch_size, 1, *flags.input_shape)
+            image, label = image.to(device), label.to(device)
             for callback in callbacks:
                 callback.on_batch_start()
 
-            for curr_image, curr_label in zip(image, label):
-                curr_image, curr_label = curr_image.to(device), curr_label.to(device)
-
-                with autocast(enabled=flags.amp):
-                    output = model(curr_image)
-                    loss_value = loss_fn(output, curr_label)
-                    loss_value /= flags.ga_steps
-
-                if flags.amp:
-                    scaler.scale(loss_value).backward()
-                else:
-                    loss_value.backward()
+            with autocast(enabled=flags.amp):
+                output = model(image)
+                loss_value = loss_fn(output, label)
+                loss_value /= flags.ga_steps
 
             if flags.amp:
-                scaler.step(optimizer)
-                scaler.update()
+                scaler.scale(loss_value).backward()
             else:
-                optimizer.step()
+                loss_value.backward()
 
-            optimizer.zero_grad()
+            if (iteration + 1) % flags.ga_steps == 0:
+                if flags.amp:
+                    scaler.step(optimizer)
+                    scaler.update()
+                else:
+                    optimizer.step()
+
+                optimizer.zero_grad()
 
             loss_value = reduce_tensor(loss_value, world_size).detach().cpu().numpy()
             cumulative_loss.append(loss_value)
@@ -124,15 +121,18 @@ def train(flags, model, train_loader, val_loader, loss_fn, score_fn, device, cal
                 callback.on_epoch_end(epoch=epoch, metrics=eval_metrics, model=model, optimizer=optimizer)
             model.train()
             if eval_metrics["mean_dice"] >= flags.quality_threshold:
-                stop_training = True
+                is_successful = True
+            elif eval_metrics["mean_dice"] < 1e-6:
+                print("MODEL DIVERGED. ABORTING.")
+                diverged = True
 
         mllog_end(key=CONSTANTS.BLOCK_STOP, sync=False,
                   metadata={CONSTANTS.FIRST_EPOCH_NUM: epoch, CONSTANTS.EPOCH_COUNT: 1})
 
-        if stop_training:
+        if is_successful or diverged:
             break
 
     mllog_end(key=CONSTANTS.RUN_STOP, sync=True,
-              metadata={CONSTANTS.STATUS: CONSTANTS.SUCCESS if stop_training else CONSTANTS.ABORTED})
+              metadata={CONSTANTS.STATUS: CONSTANTS.SUCCESS if is_successful else CONSTANTS.ABORTED})
     for callback in callbacks:
         callback.on_fit_end()


### PR DESCRIPTION
Proposed changes:

- Restored multi-gpu (multi-device) training and evaluation
    - `DistributedSampler` does not support `last batch padded` functionality, therefore `last batch dropped` is used.
    - Readme was updated to accommodate the changes
    - No changes in evaluation schedule are proposed - the dependency on revised `samples per epoch` still holds
- Fixed performance issues with gradient accumulation