### PR TITLE
[MRCNN] remove ununsed argument

### DIFF
--- a/object_detection/pytorch/tools/train_mlperf.py
+++ b/object_detection/pytorch/tools/train_mlperf.py
@@ -115,7 +115,7 @@ def cast_frozen_bn_to_half(module):
         cast_frozen_bn_to_half(child)
     return module
 
-def train(cfg, local_rank, distributed, disable_allreduce_for_logging, random_number_generator):
+def train(cfg, local_rank, distributed, random_number_generator):
     # Model logging
     log_event(key=constants.GLOBAL_BATCH_SIZE, value=cfg.SOLVER.IMS_PER_BATCH)
     log_event(key=constants.NUM_IMAGE_CANDIDATES, value=cfg.MODEL.RPN.FPN_POST_NMS_TOP_N_TRAIN)
@@ -295,7 +295,7 @@ def main():
         logger.info(config_str)
     logger.info("Running with config:\n{}".format(cfg))
 
-    model, success = train(cfg, args.local_rank, args.distributed, args.disable_allreduce_for_logging, random_number_generator)
+    model, success = train(cfg, args.local_rank, args.distributed, random_number_generator)
 
     if success is not None:
         if success:


### PR DESCRIPTION
Fix this crash:

```
Traceback (most recent call last):
  File "tools/train_mlperf.py", line 309, in <module>
    main()
  File "tools/train_mlperf.py", line 298, in main
    model, success = train(cfg, args.local_rank, args.distributed, args.disable_allreduce_for_logging, random_number_generator)
AttributeError: 'Namespace' object has no attribute 'disable_allreduce_for_logging
```