### PR TITLE
[DLRMv2] Resolve benchmark name and use other constants for logging

### DIFF
--- a/recommendation_v2/torchrec_dlrm/dlrm_main.py
+++ b/recommendation_v2/torchrec_dlrm/dlrm_main.py
@@ -848,7 +848,7 @@ def main(argv: List[str]) -> None:
     if is_rank_zero:
         mllogger.event(
             key=mllog_constants.OPT_NAME,
-            value="adagrad" if args.adagrad else mllog_constants.SGD,
+            value=mllog_constants.ADAGRAD if args.adagrad else mllog_constants.SGD,
         )
         mllogger.event(
             key=mllog_constants.OPT_BASE_LR,

--- a/recommendation_v2/torchrec_dlrm/dlrm_main.py
+++ b/recommendation_v2/torchrec_dlrm/dlrm_main.py
@@ -701,7 +701,7 @@ def main(argv: List[str]) -> None:
     is_rank_zero = dist.get_rank() == 0
     if is_rank_zero:
         pprint(vars(args))
-        submission_info(mllogger, "dcnv2", "reference_implementation")
+        submission_info(mllogger, mllog_constants.DLRMv2, "reference_implementation")
         mllogger.event(
             key=mllog_constants.GLOBAL_BATCH_SIZE,
             value=dist.get_world_size() * args.batch_size,
@@ -855,7 +855,7 @@ def main(argv: List[str]) -> None:
             value=args.learning_rate,
         )
         mllogger.event(
-            key="opt_adagrad_lr_decay",
+            key=mllog_constants.OPT_ADAGRAD_LR_DECAY,
             value=ADAGRAD_LR_DECAY,
         )
         mllogger.event(
@@ -863,11 +863,11 @@ def main(argv: List[str]) -> None:
             value=WEIGHT_DECAY,
         )
         mllogger.event(
-            key="opt_adagrad_init_acc_value",
+            key=mllog_constants.OPT_ADAGRAD_INITIAL_ACCUMULATOR_VALUE,
             value=ADAGRAD_INIT_ACC,
         )
         mllogger.event(
-            key="opt_adagrad_eps",
+            key=mllog_constants.OPT_ADAGRAD_EPSILON,
             value=ADAGRAD_EPS,
         )
         mllogger.event(

--- a/recommendation_v2/torchrec_dlrm/requirements.txt
+++ b/recommendation_v2/torchrec_dlrm/requirements.txt
@@ -1,4 +1,4 @@
 fbgemm-gpu==0.3.2
-git+https://github.com/mlcommons/logging.git@2.1.0
+git+https://github.com/janekl/logging.git@mlcommons_logging_pr297  # TODO https://github.com/mlcommons/logging/pull/297
 torchmetrics==0.11.0
 torchrec==0.3.2


### PR DESCRIPTION
Author: Jan Lasek, Nvidia (jlasek_at_nvidia_dot_com)

I'm using the final name for the new recommender benchmark -- "DLRMv2" a.k.a. "dlrmv2". I'm also employing new constants for improved logging.

Prerequisite: merge https://github.com/mlcommons/logging/pull/297.