### PR TITLE
[DLRMv2] Align optimizer parameters for embeddings and dense layers

### DIFF
--- a/recommendation_v2/torchrec_dlrm/dlrm_main.py
+++ b/recommendation_v2/torchrec_dlrm/dlrm_main.py
@@ -791,13 +791,13 @@ def main(argv: List[str]) -> None:
 
     # Note that lr_decay, weight_decay and initial_accumulator_value for Adagrad optimizer in FBGEMM v0.3.2
     # cannot be specified below. This equivalently means that all these parameters are hardcoded to zero.
+    optimizer_kwargs = {"lr": args.learning_rate}
+    if args.adagrad:
+        optimizer_kwargs["eps"] = ADAGRAD_EPS
     apply_optimizer_in_backward(
         embedding_optimizer,
         train_model.model.sparse_arch.parameters(),
-        {
-            "lr": args.learning_rate,
-            "eps": ADAGRAD_EPS,
-        },
+        optimizer_kwargs,
     )
     planner = EmbeddingShardingPlanner(
         topology=Topology(

--- a/recommendation_v2/torchrec_dlrm/dlrm_main.py
+++ b/recommendation_v2/torchrec_dlrm/dlrm_main.py
@@ -789,14 +789,13 @@ def main(argv: List[str]) -> None:
     # TorchRec will use the FBGEMM implementation of EXACT_ADAGRAD. For GPU devices, a fused CUDA kernel is invoked. For CPU, FBGEMM_GPU invokes CPU kernels
     # https://github.com/pytorch/FBGEMM/blob/2cb8b0dff3e67f9a009c4299defbd6b99cc12b8f/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops.py#L676-L678
 
-    # Note that lr_decay and initial_accumulator_value for Adagrad cannot be specified below (FBGEMM version 0.3.2).
-    # This equivalently means that both parameters are hardcoded to zero.
+    # Note that lr_decay, weight_decay and initial_accumulator_value for Adagrad optimizer in FBGEMM v0.3.2
+    # cannot be specified below. This equivalently means that all these parameters are hardcoded to zero.
     apply_optimizer_in_backward(
         embedding_optimizer,
         train_model.model.sparse_arch.parameters(),
         {
             "lr": args.learning_rate,
-            "weight_decay": WEIGHT_DECAY,
             "eps": ADAGRAD_EPS,
         },
     )

--- a/recommendation_v2/torchrec_dlrm/dlrm_main.py
+++ b/recommendation_v2/torchrec_dlrm/dlrm_main.py
@@ -788,10 +788,17 @@ def main(argv: List[str]) -> None:
     # the optimizer update will be applied in the backward pass, in this case through a fused op.
     # TorchRec will use the FBGEMM implementation of EXACT_ADAGRAD. For GPU devices, a fused CUDA kernel is invoked. For CPU, FBGEMM_GPU invokes CPU kernels
     # https://github.com/pytorch/FBGEMM/blob/2cb8b0dff3e67f9a009c4299defbd6b99cc12b8f/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops.py#L676-L678
+
+    # Note that lr_decay and initial_accumulator_value for Adagrad cannot be specified below (FBGEMM version 0.3.2).
+    # This equivalently means that both parameters are hardcoded to zero.
     apply_optimizer_in_backward(
         embedding_optimizer,
         train_model.model.sparse_arch.parameters(),
-        {"lr": args.learning_rate},
+        {
+            "lr": args.learning_rate,
+            "weight_decay": WEIGHT_DECAY,
+            "eps": ADAGRAD_EPS,
+        },
     )
     planner = EmbeddingShardingPlanner(
         topology=Topology(

--- a/recommendation_v2/torchrec_dlrm/dlrm_main.py
+++ b/recommendation_v2/torchrec_dlrm/dlrm_main.py
@@ -72,7 +72,7 @@ TRAIN_PIPELINE_STAGES = 3  # Number of stages in TrainPipelineSparseDist.
 # Optimizer parameters:
 ADAGRAD_LR_DECAY = 0
 ADAGRAD_INIT_ACC = 0
-ADAGRAD_EPS = 1e-10
+ADAGRAD_EPS = 1e-8
 WEIGHT_DECAY = 0
 
 mllogger = mllog.get_mllogger()


### PR DESCRIPTION
Author: Jan Lasek, Nvidia (jlasek_at_nvidia.com)

There is parameter mismatch for Adagrad optimizer for embeddings and dense layers in the new DLRMv2 recommender benchmark.

As the dense layers and the embeddings employ PyTorch and FBGEMM Adagrad implementations, respectively, one needs to explicitly pass all relevant optimizer parameters in `apply_optimizer_in_backward` call:
* Currently FBGEMM uses `eps=1e-8` as [default here](https://github.com/pytorch/FBGEMM/blob/v0.3.2/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops.py#L218)
* On the other hand, PyTorch uses `eps=1e-10`, see [docs here](https://pytorch.org/docs/stable/generated/torch.optim.Adagrad.html#torch.optim.Adagrad).

This causes a mismatch between the two optimizer used that I'm fixing here.