### PR TITLE
UNET3D - Change DistributedSampler seed to be same across all workers

### DIFF
--- a/image_segmentation/pytorch/data_loading/data_loader.py
+++ b/image_segmentation/pytorch/data_loading/data_loader.py
@@ -89,7 +89,8 @@ def get_data_loaders(flags, num_shards, global_rank):
     else:
         raise ValueError(f"Loader {flags.loader} unknown. Valid loaders are: synthetic, pytorch")
 
-    train_sampler = DistributedSampler(train_dataset, seed=flags.seed, drop_last=True) if num_shards > 1 else None
+    # The DistributedSampler seed should be the same for all workers
+    train_sampler = DistributedSampler(train_dataset, seed=flags.shuffling_seed, drop_last=True) if num_shards > 1 else None
     val_sampler = None
 
     train_dataloader = DataLoader(train_dataset,

--- a/image_segmentation/pytorch/main.py
+++ b/image_segmentation/pytorch/main.py
@@ -44,6 +44,7 @@ def main():
 
     callbacks = get_callbacks(flags, dllogger, local_rank, world_size)
     flags.seed = worker_seed
+    flags.shuffling_seed = shuffling_seeds[0]
     model = Unet3D(1, 3, normalization=flags.normalization, activation=flags.activation)
 
     mllog_end(key=constants.INIT_STOP, sync=True)


### PR DESCRIPTION
The DistributedSampler seed should be the same across all workers, else the data split is not exclusive. 
https://pytorch.org/docs/stable/data.html#torch.utils.data.distributed.DistributedSampler

Indeed, printing out the indexes read by each worker shows overlap (around 20% to 30%!)

It looks like the shuffling seeds might have been meant for this, but were not used. I took the first one to initialize the sampler. The seed will then be updated for each epoch by the call to `sampler.set_epoch()` already present in training.py.