### PR TITLE
Improve TensorFlow compatibility in BERT scripts

### DIFF
--- a/language_model/tensorflow/bert/cleanup_scripts/create_pretraining_data.py
+++ b/language_model/tensorflow/bert/cleanup_scripts/create_pretraining_data.py
@@ -128,8 +128,8 @@ def write_instance_to_example_files(instances, tokenizer, max_seq_length,
     total_written += 1
 
     if inst_index < 20:
-      tf.compat.v1.logging.INFO("*** Example ***")
-      tf.compat.v1.logging.INFO("tokens: %s" % " ".join(
+      tf.compat.v1.logging.info("*** Example ***")
+      tf.compat.v1.logging.info("tokens: %s" % " ".join(
           [tokenization.printable_text(x) for x in instance.tokens]))
 
       for feature_name in features.keys():
@@ -139,13 +139,13 @@ def write_instance_to_example_files(instances, tokenizer, max_seq_length,
           values = feature.int64_list.value
         elif feature.float_list.value:
           values = feature.float_list.value
-        tf.compat.v1.logging.INFO(
+        tf.compat.v1.logging.info(
             "%s: %s" % (feature_name, " ".join([str(x) for x in values])))
 
   for writer in writers:
     writer.close()
 
-  tf.compat.v1.logging.INFO("Wrote %d total instances", total_written)
+  tf.compat.v1.logging.info("Wrote %d total instances", total_written)
 
 
 def create_int_feature(values):
@@ -402,9 +402,9 @@ def main(_):
   for input_pattern in FLAGS.input_file.split(","):
     input_files.extend(tf.io.gfile.glob(input_pattern))
 
-  tf.compat.v1.logging.INFO("*** Reading from input files ***")
+  tf.compat.v1.logging.info("*** Reading from input files ***")
   for input_file in input_files:
-    tf.compat.v1.logging.INFO("  %s", input_file)
+    tf.compat.v1.logging.info("  %s", input_file)
 
   rng = random.Random(FLAGS.random_seed)
   instances = create_training_instances(
@@ -413,9 +413,9 @@ def main(_):
       rng)
 
   output_files = FLAGS.output_file.split(",")
-  tf.compat.v1.logging.INFO("*** Writing to output files ***")
+  tf.compat.v1.logging.info("*** Writing to output files ***")
   for output_file in output_files:
-    tf.compat.v1.logging.INFO("  %s", output_file)
+    tf.compat.v1.logging.info("  %s", output_file)
 
   write_instance_to_example_files(instances, tokenizer, FLAGS.max_seq_length,
                                   FLAGS.max_predictions_per_seq, output_files)
@@ -425,4 +425,4 @@ if __name__ == "__main__":
   flags.mark_flag_as_required("input_file")
   flags.mark_flag_as_required("output_file")
   flags.mark_flag_as_required("vocab_file")
-  tf.app.run()
+  tf.compat.v1.app.run()

--- a/language_model/tensorflow/bert/cleanup_scripts/create_pretraining_data.py
+++ b/language_model/tensorflow/bert/cleanup_scripts/create_pretraining_data.py
@@ -128,8 +128,8 @@ def write_instance_to_example_files(instances, tokenizer, max_seq_length,
     total_written += 1
 
     if inst_index < 20:
-      tf.logging.info("*** Example ***")
-      tf.logging.info("tokens: %s" % " ".join(
+      tf.compat.v1.logging.INFO("*** Example ***")
+      tf.compat.v1.logging.INFO("tokens: %s" % " ".join(
           [tokenization.printable_text(x) for x in instance.tokens]))
 
       for feature_name in features.keys():
@@ -139,13 +139,13 @@ def write_instance_to_example_files(instances, tokenizer, max_seq_length,
           values = feature.int64_list.value
         elif feature.float_list.value:
           values = feature.float_list.value
-        tf.logging.info(
+        tf.compat.v1.logging.INFO(
             "%s: %s" % (feature_name, " ".join([str(x) for x in values])))
 
   for writer in writers:
     writer.close()
 
-  tf.logging.info("Wrote %d total instances", total_written)
+  tf.compat.v1.logging.INFO("Wrote %d total instances", total_written)
 
 
 def create_int_feature(values):
@@ -393,18 +393,18 @@ def truncate_seq_pair(tokens_a, tokens_b, max_num_tokens, rng):
 
 
 def main(_):
-  tf.logging.set_verbosity(tf.logging.INFO)
+  tf.compat.v1.logging.set_verbosity(tf.compat.v1.logging.INFO)
 
   tokenizer = tokenization.FullTokenizer(
       vocab_file=FLAGS.vocab_file, do_lower_case=FLAGS.do_lower_case)
 
   input_files = []
   for input_pattern in FLAGS.input_file.split(","):
-    input_files.extend(tf.gfile.Glob(input_pattern))
+    input_files.extend(tf.io.gfile.glob(input_pattern))
 
-  tf.logging.info("*** Reading from input files ***")
+  tf.compat.v1.logging.INFO("*** Reading from input files ***")
   for input_file in input_files:
-    tf.logging.info("  %s", input_file)
+    tf.compat.v1.logging.INFO("  %s", input_file)
 
   rng = random.Random(FLAGS.random_seed)
   instances = create_training_instances(
@@ -413,9 +413,9 @@ def main(_):
       rng)
 
   output_files = FLAGS.output_file.split(",")
-  tf.logging.info("*** Writing to output files ***")
+  tf.compat.v1.logging.INFO("*** Writing to output files ***")
   for output_file in output_files:
-    tf.logging.info("  %s", output_file)
+    tf.compat.v1.logging.INFO("  %s", output_file)
 
   write_instance_to_example_files(instances, tokenizer, FLAGS.max_seq_length,
                                   FLAGS.max_predictions_per_seq, output_files)

--- a/language_model/tensorflow/bert/cleanup_scripts/create_pretraining_data.py
+++ b/language_model/tensorflow/bert/cleanup_scripts/create_pretraining_data.py
@@ -171,7 +171,7 @@ def create_training_instances(input_files, tokenizer, max_seq_length,
   # (2) Blank lines between documents. Document boundaries are needed so
   # that the "next sentence prediction" task doesn't span between documents.
   for input_file in input_files:
-    with tf.gfile.GFile(input_file, "r") as reader:
+    with tf.io.gfile.GFile(input_file, "r") as reader:
       while True:
         line = tokenization.convert_to_unicode(reader.readline())
         if not line:


### PR DESCRIPTION
Hello mlcommons team!

Trying to run [training/language_model/tensorflow/bert/cleanup_scripts/create_pretraining_data.py](https://github.com/mlcommons/training/blob/2b2caf7f8ed5474b68a2b4965c49e152a716b7be/language_model/tensorflow/bert/cleanup_scripts/create_pretraining_data.py) with TensorFlow 1.15.4 and Python 3.6.9, I faced several warnings as below:

![image](https://github.com/mlcommons/training/assets/14137676/3910f886-287d-4ed1-a709-778f34d9d47b)

I'm not sure which TensorFlow version is recommended to run this script, but these changes will be helpful for future migration to TensorFlow 2.x.

| Before | After |
| ------- | ---- |
| tf.app.run() | tf.compat.v1.app.run() |
| tf.logging.set_verbosity() | tf.compat.v1.logging.set_verbosity() |
| tf.logging.INFO | tf.compat.v1.logging.INFO |
| tf.gfile.GFile | tf.io.gfile.GFile |
| tf.gfile.Glob | tf.io.gfile.glob |
| tf.logging.info() | tf.compat.v1.logging.info() |
