### PR TITLE
Add `distribution_strategy` and `all_reduce_alg` flags to TensorFlow BERT pretraining

### DIFF
--- a/language_model/tensorflow/bert/run_pretraining.py
+++ b/language_model/tensorflow/bert/run_pretraining.py
@@ -117,6 +117,28 @@ flags.DEFINE_integer("steps_per_update", 1,
 flags.DEFINE_integer("keep_checkpoint_max", 5,
                      "The maximum number of checkpoints to keep.")
 
+flags.DEFINE_string(
+    name="distribution_strategy", short_name="ds", default="mirrored",
+    help="The Distribution Strategy to use for training. "
+         "Accepted values are 'off', 'one_device', "
+         "'mirrored', 'parameter_server', 'collective', "
+         "case insensitive. 'off' means not to use "
+         "Distribution Strategy; 'default' means to choose "
+         "from `MirroredStrategy` or `OneDeviceStrategy` "
+         "according to the number of GPUs.")
+
+flags.DEFINE_string(
+    name="all_reduce_alg", short_name="ara", default="nccl",
+    help="Defines the algorithm to use for performing all-reduce."
+         "When specified with MirroredStrategy for single "
+         "worker, this controls "
+         "tf.contrib.distribute.AllReduceCrossTowerOps.  When "
+         "specified with MultiWorkerMirroredStrategy, this "
+         "controls "
+         "tf.distribute.experimental.CollectiveCommunication; "
+         "valid options are `ring` and `nccl`.")
+
+
 def model_fn_builder(bert_config, init_checkpoint, learning_rate,
                      num_train_steps, num_warmup_steps, use_tpu,
                      use_one_hot_embeddings, optimizer, poly_power,
@@ -542,9 +564,9 @@ def main(_):
         allow_soft_placement=True)
 
     distribution_strategy = distribution_utils.get_distribution_strategy(
-        distribution_strategy="mirrored",
+        distribution_strategy=flags.distribution_strategy,
         num_gpus=FLAGS.num_gpus,
-        all_reduce_alg="nccl",
+        all_reduce_alg=flags.all_reduce_alg,
         num_packs=0)
 
     dist_gpu_config = tf.estimator.RunConfig(

--- a/language_model/tensorflow/bert/run_pretraining.py
+++ b/language_model/tensorflow/bert/run_pretraining.py
@@ -564,9 +564,9 @@ def main(_):
         allow_soft_placement=True)
 
     distribution_strategy = distribution_utils.get_distribution_strategy(
-        distribution_strategy=flags.distribution_strategy,
+        distribution_strategy=FLAGS.distribution_strategy,
         num_gpus=FLAGS.num_gpus,
-        all_reduce_alg=flags.all_reduce_alg,
+        all_reduce_alg=FLAGS.all_reduce_alg,
         num_packs=0)
 
     dist_gpu_config = tf.estimator.RunConfig(


### PR DESCRIPTION
Hello mlcommons team!

I've noticed that some utilities, such as additional flags, are missing in BERT pretraining, unlike ResNet50 image classification. This pull request is expected to be helpful to run BERT training on distributed environment.

References are below:
https://github.com/mlcommons/training/blob/f0a7d0cd2e9fa198ad7cd53ee68e7be47495127e/image_classification/tensorflow2/tf2_common/utils/flags/_base.py#L140-L150
https://github.com/mlcommons/training/blob/f0a7d0cd2e9fa198ad7cd53ee68e7be47495127e/image_classification/tensorflow2/tf2_common/utils/flags/_performance.py#L224-L234

Refs
- #384
