### PR TITLE
[Llama 3.1] Updates dataset, logging, and checkpoint resume. 

### DIFF
--- a/large_language_model_pretraining/nemo/README.md
+++ b/large_language_model_pretraining/nemo/README.md
@@ -102,7 +102,7 @@ After the download is complete, you should see five files under `TOKENIZER_PATH`
 
 We use the default split from the C4 dataset. This means that we use `c4-train.<x>-of-01024.json.gz` files (where `768 <= x <= 1023`) for training, and we use our customized `c4-validation-91205-samples.en.json.gz`, which contains the first 91205 samples from the unshuffled C4 validation dataset, for evaluation. 
 
-Notice here that we are using the first 47,185,920 tokens (5760 sequences) from the validation dataset to perform the validation. According to our experiments, the first 91205 samples from the unshuffled C4 dataset yields 47,186,855 tokens, which is the smallest amount of samples needed to yield 47,185,920 tokens. Thus, we have chosen the first 91205 samples as our validation dataset. 
+Notice here that we are using the first 5760 sequences (47,185,920 tokens) from the validation dataset to perform the validation. According to our experiments, the first 91205 samples from the unshuffled C4 dataset yields 47,186,855 tokens, which is the smallest amount of samples needed to yield 47,185,920 tokens. Thus, we have chosen the first 91205 samples as our validation dataset. 
 
 ### Training data order
 
@@ -110,7 +110,7 @@ We randomly shuffle the **last 256 of 1024 shards** for the benchmarking area.
 
 ### Test data order
 
-We use the first 47,185,920 tokens in the validation dataset for validation. We **do not shuffle** the validation dataset. 
+We use the first 5,760 sequences (91,205 untokenized samples) in the validation dataset for validation. We **do not shuffle** the validation dataset. 
 
 # 4. Model
 ### Publication/Attribution

--- a/large_language_model_pretraining/nemo/README.md
+++ b/large_language_model_pretraining/nemo/README.md
@@ -78,7 +78,6 @@ You can then navigate in the terminal to your desired download directory and run
 export PREPROCESSED_PATH="./"
 rclone copy mlc-training:mlcommons-training-wg-public/common/datasets/c4/mixtral_8x22b_preprocessed $PREPROCESSED_PATH -P
 
-# There is a typo in the uploaded file names
 mv $PREPROCESSED_PATH/c4-validationn-91205-samples.en_text_document.bin $PREPROCESSED_PATH/c4-validation-91205-samples.en_text_document.bin
 mv $PREPROCESSED_PATH/c4-validationn-91205-samples.en_text_document.idx $PREPROCESSED_PATH/c4-validation-91205-samples.en_text_document.idx
 ```

--- a/large_language_model_pretraining/nemo/README.md
+++ b/large_language_model_pretraining/nemo/README.md
@@ -77,9 +77,6 @@ You can then navigate in the terminal to your desired download directory and run
 # Replace this path with your desired path on the machine
 export PREPROCESSED_PATH="./"
 rclone copy mlc-training:mlcommons-training-wg-public/common/datasets/c4/mixtral_8x22b_preprocessed $PREPROCESSED_PATH -P
-
-mv $PREPROCESSED_PATH/c4-validationn-91205-samples.en_text_document.bin $PREPROCESSED_PATH/c4-validation-91205-samples.en_text_document.bin
-mv $PREPROCESSED_PATH/c4-validationn-91205-samples.en_text_document.idx $PREPROCESSED_PATH/c4-validation-91205-samples.en_text_document.idx
 ```
 
 After the download is complete, you should see files with the following naming conventions under `PREPROCESSED_PATH`, ending with both `.idx` and `.bin`: 

--- a/large_language_model_pretraining/nemo/README.md
+++ b/large_language_model_pretraining/nemo/README.md
@@ -102,13 +102,15 @@ After the download is complete, you should see five files under `TOKENIZER_PATH`
 
 We use the default split from the C4 dataset. This means that we use `c4-train.<x>-of-01024.json.gz` files (where `768 <= x <= 1023`) for training, and we use our customized `c4-validation-91205-samples.en.json.gz`, which contains the first 91205 samples from the unshuffled C4 validation dataset, for evaluation. 
 
+Notice here that we are using the first 47,185,920 tokens (5760 sequences) from the validation dataset to perform the validation. According to our experiments, the first 91205 samples from the unshuffled C4 dataset yields 47,186,855 tokens, which is the smallest amount of samples needed to yield 47,185,920 tokens. Thus, we have chosen the first 91205 samples as our validation dataset. 
+
 ### Training data order
 
 We randomly shuffle the **last 256 of 1024 shards** for the benchmarking area.
 
 ### Test data order
 
-We use the first 47M tokens in the validation dataset for validation. We **do not shuffle** the validation dataset. 
+We use the first 47,185,920 tokens in the validation dataset for validation. We **do not shuffle** the validation dataset. 
 
 # 4. Model
 ### Publication/Attribution
@@ -159,7 +161,7 @@ Validation log perplexity = 5.6
 
 ### Evaluation frequency
 
-We perform evaluation every **46080** sequences. 
+We perform evaluation every **46,080** sequences. 
 
 ### Evaluation thoroughness
 

--- a/large_language_model_pretraining/nemo/callbacks.py
+++ b/large_language_model_pretraining/nemo/callbacks.py
@@ -148,7 +148,7 @@ class MetricsLogger(Logger):
 ### MLPerf callbacks
 def compute_consumed_mllog_tokens(trainer, init_global_step, global_batch_size, seq_length):
     consumed_samples = (
-        (trainer.global_step + 1) * global_batch_size # global steps are 0-indexed
+        trainer.global_step * global_batch_size
     )
     return int(consumed_samples) # we log the epoch numbers in sequences, not tokens
 

--- a/large_language_model_pretraining/nemo/pretrain_llama31.py
+++ b/large_language_model_pretraining/nemo/pretrain_llama31.py
@@ -386,10 +386,10 @@ if __name__ == "__main__":
         # Optimizers
         constants.OPT_NAME: "adamw", 
         constants.OPT_BASE_LR: pretrain.optim.config.lr,
-        constants.OPT_ADAM_BETA_1: pretrain.optim.config.adam_beta1,
-        constants.OPT_ADAM_BETA_2: pretrain.optim.config.adam_beta2,
-        constants.OPT_ADAM_EPSILON: pretrain.optim.config.adam_eps,
-        constants.OPT_WEIGHT_DECAY: pretrain.optim.config.weight_decay,
+        constants.OPT_ADAMW_BETA_1: pretrain.optim.config.adam_beta1,
+        constants.OPT_ADAMW_BETA_2: pretrain.optim.config.adam_beta2,
+        constants.OPT_ADAMW_EPSILON: pretrain.optim.config.adam_eps,
+        constants.OPT_ADAMW_WEIGHT_DECAY: pretrain.optim.config.weight_decay,
         constants.OPT_GRADIENT_CLIP_NORM: pretrain.optim.config.clip_grad,
 
         # Schedulers

--- a/large_language_model_pretraining/nemo/run_llama31.sh
+++ b/large_language_model_pretraining/nemo/run_llama31.sh
@@ -59,8 +59,6 @@ git config --global --add safe.directory /workspace/llama31
 : "${START_STEPS:=0}"
 
 #     Dataloader settings
-: "${EVAL_EVERY:=""}"
-: "${EVAL_TOKENS:=""}"
 : "${MAX_STEPS:=""}"
 
 #     Experiment settings
@@ -68,9 +66,10 @@ git config --global --add safe.directory /workspace/llama31
 IFS=" " read -ra seeds <<< $SEEDS
 : "${NEXP:=1}"
 : "${NPAR:=1}"
-: "${SAVE_CKPT:=1}"
+: "${SAVE_CKPT:=0}"
 : "${TAG:=""}"
 : "${TARGET:="5.6"}"
+: "${STEP_TIME_ATOL:="7200"}" # maximum tolerable step time, setting to 2hr by default
 
 # Run
 
@@ -107,14 +106,6 @@ if [ ! $DEPENDENCIES = "" ]; then
     CMD_SUFFIX="${CMD_SUFFIX} --dependencies ${DEPENDENCIES}"
 fi
 
-if [ ! $EVAL_EVERY = "" ]; then
-    CMD_SUFFIX="${CMD_SUFFIX} --eval_every ${EVAL_EVERY}"
-fi
-
-if [ ! $EVAL_TOKENS = "" ]; then
-    CMD_SUFFIX="${CMD_SUFFIX} --eval_tokens ${EVAL_TOKENS}"
-fi
-
 if [ ! $MAX_STEPS = "" ]; then
     CMD_SUFFIX="${CMD_SUFFIX} --max_steps ${MAX_STEPS}"
 fi
@@ -145,6 +136,7 @@ python3 pretrain_llama31.py \
 --continual_ckpt_path /continual \
 --tokenizer_path /tokenizer \
 --target_log_ppl $TARGET \
+--step_time_atol $STEP_TIME_ATOL \
 --ckpt_start_step $START_STEPS \
 --max_retries $MAX_RETRIES \
 $CMD_SUFFIX

--- a/large_language_model_pretraining/nemo/utils/consolidate_data.sh
+++ b/large_language_model_pretraining/nemo/utils/consolidate_data.sh
@@ -2,6 +2,11 @@ set -e
 
 : "${C4_PATH:?C4_PATH not set}"
 : "${MERGED_C4_PATH:?MERGED_C4_PATH not set}"
+: "${N_VALIDATION_SAMPLES:=91205}"
+# defaults the N_VALIDATION_SAMPLES to 91205
+# C4 validation dataset: each sample on average tokenizes to 518 tokens
+# thus, to reach 47,185,920 validation tokens, we need to use at least 91205 samples,
+# which, after tokenization, will yield 47,186,855 tokens. 
 
 # create softlinks to store each shard before merging
 mkdir -p softlinks
@@ -27,3 +32,6 @@ for shard in {0..7}; do
 done
 
 cat softlinks/en_validation/*gz > ${MERGED_C4_PATH}/c4-validation.en.json.gz
+
+# select the first N_VALIDATION_SAMPLES number of samples
+zcat ${MERGED_C4_PATH}/c4-validation.en.json.gz | head -n $N_VALIDATION_SAMPLES | gzip > ${MERGED_C4_PATH}/c4-validation-${N_VALIDATION_SAMPLES}-samples.en.json.gz

--- a/large_language_model_pretraining/nemo/utils/preprocess.sh
+++ b/large_language_model_pretraining/nemo/utils/preprocess.sh
@@ -27,8 +27,8 @@ srun --nodes=1 --ntasks-per-node=1 \
     --container-image=$CONT_IMAGE_URL --container-mounts $container_maps --no-container-entrypoint \
     --output preprocess_outputs/dataset_preprocess_validation.out \
     python3 /opt/NeMo/scripts/nlp_language_modeling/preprocess_data_for_megatron.py \
-    --input "/dataset/c4-validation.en.json.gz" \
-    --output-prefix "/outputs/c4-validation.en" \
+    --input "/dataset/c4-validation-91205-samples.en.json.gz" \
+    --output-prefix "/outputs/c4-validation-91205-samples.en" \
     --tokenizer-library huggingface --tokenizer-type /tokenizer \
     --dataset-impl mmap --workers 128 & 
 wait

--- a/mixture_of_experts_pretraining/README.md
+++ b/mixture_of_experts_pretraining/README.md
@@ -492,12 +492,16 @@ You can then navigate in the terminal to your desired download directory and run
 
 ## Text Datasets
 **Dataset**
-* Train Dataset`c4/en_json/3.0.1`
-* Eval Dataset `c4/en_val_subset_json`
-* Preprocessed GPU dataset `preprocessed_c4`
+* Train Dataset`original/en_json/3.0.1`
+* Eval Dataset `original/en_val_subset_json`
+* Preprocessed GPU dataset `mixtral_8x22b_preprocessed`
 ```
 mkdir -p datasets
-rclone copy mlc-training:mlcommons-training-wg-public/mixtral_8x22b/datasets ./datasets -P
+rclone copy mlc-training:mlcommons-training-wg-public/common/datasets/c4 ./datasets -P
+
+# moving them to the original naming convention so that it won't break the code
+mv ./datasets/original ./datasets/c4
+mv ./datasets/mixtral_8x22b_preprocessed ./datasets/preprocessed_c4
 ```
 ## Checkpoints
 * Mixtral-8x22B-v0.1-fsdp: use for `tensor_parallelism=1`


### PR DESCRIPTION
This PR includes the following changes: 
- Llama 3.1: 
    1. Updated the validation dataset so that it now contains strictly only 5760 sequences. This impacts the preprocessing script, README downloading instructions, and pretraining script's dataset loading section. 
    2. Updated logging to log number of sequences, instead of number of tokens. This impacts the README descriptions, pretrain launch script's arguments, and callback's logging. 
    3. Updated the dataset location on the S3 bucket in the README. 
    4. Added a knob `STEP_TIME_ATOL` so that, if a training step time is longer than this threshold, then we actively kill this job. Defaults to 2hrs per step. 
    5. Updated how the checkpoints are resumed across different experiment partitions when we start from HF checkpoint. 
    6. Updated the optimizer logging to AdamW.
        - Related logging PR: [PR 408](https://github.com/mlcommons/logging/pull/408)
        - Related policies PR: [PR 553](https://github.com/mlcommons/training_policies/pull/553)
- Mixtral 8x22b: Updated the dataset downloading section in the README. 