### PR TITLE
use more robust validation, defined at dataset level

### DIFF
--- a/text_to_image/README.md
+++ b/text_to_image/README.md
@@ -281,6 +281,9 @@ In turn, the model code is largely based on the model open-sourced in [huggingfa
 The MSE calculated over latents is used for the loss
 ### Optimizer
 AdamW
+### Randomness
+For own implementations, an important detail is that each data parallel rank has its own seed, derived from the main seed.
+This is imperative so that each rank generates different noise to be added to the training samples.
 ### Precision
 The model runs with BF16 by default. This can be changed by setting `--training.mixed_precision_param=float32`.
 ### Weight initialization

--- a/text_to_image/README.md
+++ b/text_to_image/README.md
@@ -78,6 +78,8 @@ The filter file is included in this repository. It was generated using `torchtit
 
 ### COCO-2014 subset
 
+For validation purposes, each sample of the dataset is associated with a timestep that is used to evaluate it.
+For more details, consult the [evaluation algorithm](#quality-metric)
 To download the cleaned data, run the following:
 
 **Note:** We reccomend training directly on preprocessed embeddings. To do that, skip [here](#preprocessing).
@@ -288,6 +290,9 @@ For precise details, we encourage the consultation of the code at `torchtitan/ex
 # 5. Quality
 ### Quality metric
 Validation loss averaged over 8 equidistant time steps [0, 7/8], as described in [Scaling Rectified Flow Transformers for High-Resolution Image Synthesis](https://arxiv.org/pdf/2403.03206).
+The validation dataset is prepared in advance so that each sample is associated with a timestep.
+This is an integer from 0 to 7 inclusive, and thus should be divided by `8.0` to obtain the timestep.
+
 The algorithm is as follows:
 
 ```pseudocode
@@ -313,6 +318,9 @@ validation_loss = mean(mean_per_timestep)
 
 RETURN validation_loss
 ```
+
+As we ensure that the validation set has an equal number of samples per timestep, 
+a simple average of all loss values is equivalent to the above.
 
 ### Quality target
 0.586


### PR DESCRIPTION
This pr introduces changes to the validation to make it more uniform amongst submitters, making errors harder. Changes are as follows:

## Background
During a model forward step, the model attempts to denoise a latent. To do this, we take a latent from an image (will be our ground truth) and add noise to it. The amount of noise we add depends on the `timestep`, a value from 0 to 1. Naturally, the more noise we add, the harder the denoising task, and so the larger the loss we should expect.

## Validation
For validation, we follow the flux paper. We 8 equally spaced timesteps from [0, 1) -> (0, 1/8, 2/8, 3/8, 4/8, 5/8, 6/8, 7/8) and try to sample equally from them.
This means we have to select one of these timesteps for each validation sample.

### Current approach
Currently, this is done dynamically at train time. If we let each sample have a # which corresponds to its order, its timestep will be (# % 8) / 8. Basically, we cycle from 0 to 7 over and over.
While for standard training this is fine, I realized there are a few edge cases which dont make this ideal for a benchmark:
1. There might be some weird combinations of batch sizes and numbers of devices that dont evenly divide the validation dataset. This might mean some timesteps have slightly more samples than others, so folks would calculate slightly different validation losses.
2. We rely on folks to correctly implement the same logic as the reference. If they dont, they might calculate a different validation loss.

### Proposed solution
Rather than doing this dynamically, I propose that, at validation dataset creation time, we associate each sample with a timestep. This sample will always be evaluated with the same timestep regardless of parallelisms or framework. This ensures everyone calculates exactly the same validation metric.
The order used for this would be the exact same the reference currently generates dynamically, so there would be no need to regenerate RCPs (I did verify this anyway and the convergence is unchanged)