### PR TITLE
[single_stage_detector] Updated run_and_time.sh for customizing number of GPUs on single node

### DIFF
--- a/single_stage_detector/ssd/run_and_time.sh
+++ b/single_stage_detector/ssd/run_and_time.sh
@@ -36,6 +36,7 @@ BATCHSIZE=${BATCHSIZE:-2}
 EVALBATCHSIZE=${EVALBATCHSIZE:-${BATCHSIZE}}
 NUMEPOCHS=${NUMEPOCHS:-30}
 LOG_INTERVAL=${LOG_INTERVAL:-20}
+DATASET=${DATASET:-"openimages-mlperf"}
 DATASET_DIR=${DATASET_DIR:-"/datasets/open-images-v6-mlperf"}
 TORCH_HOME=${TORCH_HOME:-"$(pwd)/torch-model-cache"}
 
@@ -85,6 +86,7 @@ PARAMS=(
       --eval-batch-size         "${EVALBATCHSIZE}"
       --epochs                  "${NUMEPOCHS}"
       --print-freq              "${LOG_INTERVAL}"
+      --dataset                 "${DATASET}"
       --data-path               "${DATASET_DIR}"
 )
 

--- a/single_stage_detector/ssd/run_and_time.sh
+++ b/single_stage_detector/ssd/run_and_time.sh
@@ -39,6 +39,7 @@ LOG_INTERVAL=${LOG_INTERVAL:-20}
 DATASET=${DATASET:-"openimages-mlperf"}
 DATASET_DIR=${DATASET_DIR:-"/datasets/open-images-v6-mlperf"}
 TORCH_HOME=${TORCH_HOME:-"$(pwd)/torch-model-cache"}
+DGXNGPU=${DGXNGPU:-1}
 
 # Handle MLCube parameters
 while [ $# -gt 0 ]; do
@@ -77,7 +78,7 @@ if [ -n "${SLURM_LOCALID-}" ]; then
   fi
 else
   # Mode 2: Single-node Docker; need to launch tasks with torchrun
-  CMD=( "torchrun" "--standalone" "--nnodes=1" "--nproc_per_node=1" )
+  CMD=( "torchrun" "--standalone" "--nnodes=1" "--nproc_per_node=${DGXNGPU}" )
   [ "$MEMBIND" = false ] &&  CMD+=( "--no_membind" )
 fi
 

--- a/single_stage_detector/ssd/run_and_time.sh
+++ b/single_stage_detector/ssd/run_and_time.sh
@@ -36,7 +36,6 @@ BATCHSIZE=${BATCHSIZE:-2}
 EVALBATCHSIZE=${EVALBATCHSIZE:-${BATCHSIZE}}
 NUMEPOCHS=${NUMEPOCHS:-30}
 LOG_INTERVAL=${LOG_INTERVAL:-20}
-DATASET=${DATASET:-"openimages-mlperf"}
 DATASET_DIR=${DATASET_DIR:-"/datasets/open-images-v6-mlperf"}
 TORCH_HOME=${TORCH_HOME:-"$(pwd)/torch-model-cache"}
 DGXNGPU=${DGXNGPU:-1}
@@ -87,7 +86,6 @@ PARAMS=(
       --eval-batch-size         "${EVALBATCHSIZE}"
       --epochs                  "${NUMEPOCHS}"
       --print-freq              "${LOG_INTERVAL}"
-      --dataset                 "${DATASET}"
       --data-path               "${DATASET_DIR}"
 )
 


### PR DESCRIPTION
Dear MLCommons team,

I appreciate your work, which has helped me verify the training performance after applying hardware resource virtualization to our bare-metal server.

I want to validate the model training performance in a reasonable time on both virtualized and non-virtualized environments. However, this is very challenging with the default Open Images dataset and our relatively small GPUs in a single node. Thus, I made some changes to the performance evaluation script, which may help others with similar use cases.

This pull request modifies the `run_and_time.sh` of SSD training, and introduces the following changes:
- ~Added `DATASET` environment variable for dataset customization. This allows the script to run the training script with datasets other than the default Open Image dataset. (For example, I use the `coco` dataset.)~
  (Reverted: https://github.com/mlcommons/training/pull/808#discussion_r2263293110)
- Changed `--nproc_per_node=1` of `torchrun` command line to `--nproc_per_node=${DGXNGPU}`. This enables the script to do training with more GPUs on a single node.