### PR TITLE
Switch from Rclone to R2 Downloader in READMEs for benchmarks using C4 dataset and/or Mixtral 8x22b tokenizer

### DIFF
--- a/large_language_model_pretraining/nemo/README.md
+++ b/large_language_model_pretraining/nemo/README.md
@@ -55,28 +55,16 @@ We use the Mixtral 8x22B tokenizer from [HuggingFace/MistralAI](https://huggingf
 
 ### Preprocessed data download
 
-The pre-tokenized dataset and the tokenizer are available to download from the S3 bucket. You can download this data from the bucket using RClone as follows: 
+The pre-tokenized dataset and the tokenizer are available to download from the S3 bucket. You can download this data from the bucket using the [MLCommons R2 Downloader](https://github.com/mlcommons/r2-downloader): 
 
-To run Rclone on Windows, you can download the executable [here](https://rclone.org/install/#windows). To install Rclone on Linux/macOS/BSD systems, run:
-
-```
-sudo -v ; curl https://rclone.org/install.sh | sudo bash
-```
-
-Once Rclone is installed, run the following command to authenticate with the bucket:
-
-```
-rclone config create mlc-training s3 provider=Cloudflare access_key_id=76ea42eadb867e854061a1806220ee1e secret_access_key=a53625c4d45e3ca8ac0df8a353ea3a41ffc3292aa25259addd8b7dc5a6ce2936 endpoint=https://c2686074cb2caf5cbaf6d134bdba8b47.r2.cloudflarestorage.com
-```
-
-You can then navigate in the terminal to your desired download directory and run the following commands to download the dataset and checkpoints: 
+Navigate in the terminal to your desired download directory and run the following commands to download the dataset and checkpoints. More information about the MLCommons R2 Downloader, including how to run it on Windows, can be found [here](https://training.mlcommons-storage.org).
 
 #### Dataset
 
-```
+```bash
 # Replace this path with your desired path on the machine
 export PREPROCESSED_PATH="./"
-rclone copy mlc-training:mlcommons-training-wg-public/common/datasets/c4/mixtral_8x22b_preprocessed $PREPROCESSED_PATH -P
+bash <(curl -s https://raw.githubusercontent.com/mlcommons/r2-downloader/refs/heads/main/mlc-r2-downloader.sh) -d $PREPROCESSED_PATH https://training.mlcommons-storage.org/metadata/mixtral-8x22b-preprocessed-c4-dataset.uri
 ```
 
 After the download is complete, you should see files with the following naming conventions under `PREPROCESSED_PATH`, ending with both `.idx` and `.bin`: 
@@ -85,10 +73,10 @@ After the download is complete, you should see files with the following naming c
 
 #### Tokenizer
 
-```
+```bash
 # Replace this path with your desired path on the machine
 export TOKENIZER_PATH="./"
-rclone copy mlc-training:mlcommons-training-wg-public/llama3_1/datasets/tokenizer $TOKENIZER_PATH -P
+bash <(curl -s https://raw.githubusercontent.com/mlcommons/r2-downloader/refs/heads/main/mlc-r2-downloader.sh) -d $TOKENIZER_PATH https://training.mlcommons-storage.org/metadata/mixtral-8x22b-tokenizer.uri
 ```
 
 After the download is complete, you should see five files under `TOKENIZER_PATH`: 
@@ -138,7 +126,7 @@ The model largely follows the Llama 3.1 405B [paper](https://arxiv.org/abs/2407.
 
 ### Checkpoint download
 
-MLCommons hosts the checkpoint for download **exclusively by MLCommons Members**. You must first agree to the [confidentiality notice](https://llama3-1.mlcommons.org) using your organizational email address, then you will receive a link to a directory containing Rclone download instructions. _If you cannot access the form but you are part of a MLCommons Member organization, submit the [MLCommons subscription form](https://mlcommons.org/community/subscribe/) with your organizational email address and [associate a Google account](https://accounts.google.com/SignUpWithoutGmail) with your organizational email address. You should then be able to access the confidentiality form using that Google account._
+MLCommons hosts the checkpoint for download **exclusively by MLCommons Members**. You must first agree to the [confidentiality notice](https://llama3-1.mlcommons.org) using your organizational email address, then you will receive a link to a download directions page with MLCommons R2 Downloader commands. _If you cannot access the form but you are part of a MLCommons Member organization, submit the [MLCommons subscription form](https://mlcommons.org/community/subscribe/) with your organizational email address and [associate a Google account](https://accounts.google.com/SignUpWithoutGmail) with your organizational email address. You should then be able to access the confidentiality form using that Google account._
 
 #### Saving and restoring a checkpoint
 
@@ -182,7 +170,7 @@ We use [AllenAI C4](https://huggingface.co/datasets/allenai/c4) dataset for this
 export ORIGINAL_C4_PATH=""
 
 # download the customized zipped validation dataset
-rclone copy mlc-training:mlcommons-training-wg-public/common/datasets/c4/original/c4-validation-91205-samples.en.json.gz $ORIGINAL_C4_PATH -P
+bash <(curl -s https://raw.githubusercontent.com/mlcommons/r2-downloader/refs/heads/main/mlc-r2-downloader.sh) -d $ORIGINAL_C4_PATH https://training.mlcommons-storage.org/metadata/c4-validation-dataset-zipped.uri
 ```
 
 Alternatively, we have also hosted the **unzipped C4 `json`** files on MLCommons S3 bucket. You can download them using the following commands: 
@@ -191,14 +179,21 @@ Alternatively, we have also hosted the **unzipped C4 `json`** files on MLCommons
 export ORIGINAL_C4_PATH=""
 
 # download the full C4 files, including all raw train and validations
-rclone copy mlc-training:mlcommons-training-wg-public/common/datasets/c4/original/en_json/3.0.1 $ORIGINAL_C4_PATH -P
+bash <(curl -s https://raw.githubusercontent.com/mlcommons/r2-downloader/refs/heads/main/mlc-r2-downloader.sh) -d $ORIGINAL_C4_PATH https://training.mlcommons-storage.org/metadata/c4-full-dataset-unzipped.uri
 ```
 
 Note that for unzipped JSON files, it is recommended to zip them into `.gz` format before running the data preprocessing. 
 
 #### Prepare tokenizer
 
-We use Mixtral 8x22B tokenizer in this benchmark. Tokenizer files can be downloaded [here](https://huggingface.co/mistralai/Mixtral-8x22B-v0.1/tree/main). Only the five files containing tokenizer-related contents (`special_tokens_map.json`, `tokenizer.json`, `tokenizer.model`, `tokenizer.model.v1`, `tokenizer_config.json`) are needed. 
+We use Mixtral 8x22B tokenizer in this benchmark. Tokenizer files can be downloaded [here](https://huggingface.co/mistralai/Mixtral-8x22B-v0.1/tree/main). Only the five files containing tokenizer-related contents (`special_tokens_map.json`, `tokenizer.json`, `tokenizer.model`, `tokenizer.model.v1`, `tokenizer_config.json`) are needed.
+
+You can download just that subset of files using the following command:
+
+```bash
+export TOKENIZER_PATH=""
+bash <(curl -s https://raw.githubusercontent.com/mlcommons/r2-downloader/refs/heads/main/mlc-r2-downloader.sh) -d $TOKENIZER_PATH https://training.mlcommons-storage.org/metadata/mixtral-8x22b-tokenizer.uri
+```
 
 #### Run data preprocessing
 

--- a/retired_benchmarks/mixtral8x22b/README.md
+++ b/retired_benchmarks/mixtral8x22b/README.md
@@ -477,18 +477,6 @@ black mixture_of_experts_pretraining/
 ```
 
 # 9. S3 artifacts download
-The dataset, docker image and the checkpoints are available to download from an S3 bucket. You can download this data from the bucket using Rclone as follows:
-
-To run Rclone on Windows, you can download the executable [here](https://rclone.org/install/#windows).
-To install Rclone on Linux/macOS/BSD systems, run:
-```
-sudo -v ; curl https://rclone.org/install.sh | sudo bash
-```
-Once Rclone is installed, run the following command to authenticate with the bucket:
-```
-rclone config create mlc-training s3 provider=Cloudflare access_key_id=76ea42eadb867e854061a1806220ee1e secret_access_key=a53625c4d45e3ca8ac0df8a353ea3a41ffc3292aa25259addd8b7dc5a6ce2936 endpoint=https://c2686074cb2caf5cbaf6d134bdba8b47.r2.cloudflarestorage.com
-```
-You can then navigate in the terminal to your desired download directory and run the following commands to download the dataset and checkpoints:
 
 ## Text Datasets
 **Dataset**
@@ -496,27 +484,24 @@ You can then navigate in the terminal to your desired download directory and run
 * Eval Dataset `original/en_val_subset_json`
 * Preprocessed GPU dataset `mixtral_8x22b_preprocessed`
 ```
-mkdir -p datasets
-rclone copy mlc-training:mlcommons-training-wg-public/common/datasets/c4 ./datasets -P
-
-# moving them to the original naming convention so that it won't break the code
-mv ./datasets/original ./datasets/c4
-mv ./datasets/mixtral_8x22b_preprocessed ./datasets/preprocessed_c4
+# Train and eval datasets
+bash <(curl -s https://raw.githubusercontent.com/mlcommons/r2-downloader/refs/heads/main/mlc-r2-downloader.sh) -d datasets/c4 https://training.mlcommons-storage.org/metadata/c4-train-and-eval-datasets.uri
+```
+```
+# Preprocessed dataset
+bash <(curl -s https://raw.githubusercontent.com/mlcommons/r2-downloader/refs/heads/main/mlc-r2-downloader.sh) -d datasets/preprocessed_c4 https://training.mlcommons-storage.org/metadata/mixtral-8x22b-preprocessed-c4-dataset.uri
 ```
 ## Checkpoints
 * Mixtral-8x22B-v0.1-fsdp: use for `tensor_parallelism=1`
 ```
-mkdir -p checkpoints/Mixtral-8x22B-v0.1-fsdp
-rclone copy mlc-training:mlcommons-training-wg-public/mixtral_8x22b/checkpoints/Mixtral-8x22B-v0.1-fsdp ./datasets/Mixtral-8x22B-v0.1-fsdp -P
+bash <(curl -s https://raw.githubusercontent.com/mlcommons/r2-downloader/refs/heads/main/mlc-r2-downloader.sh) -d checkpoints/Mixtral-8x22B-v0.1-fsdp https://training.mlcommons-storage.org/metadata/mixtral-8x22b-v0-1-fsdp-checkpoint.uri
 ```
 * Mixtral-8x22B-v0.1-2d-fsdp-tp: use for `tensor_parallelism` > 1
 ```
-mkdir -p checkpoints/Mixtral-8x22B-v0.1-2d-fsdp-tp
-rclone copy mlc-training:mlcommons-training-wg-public/mixtral_8x22b/checkpoints/Mixtral-8x22B-v0.1-2d-fsdp-tp ./datasets/Mixtral-8x22B-v0.1-fsdp -P
+bash <(curl -s https://raw.githubusercontent.com/mlcommons/r2-downloader/refs/heads/main/mlc-r2-downloader.sh) -d checkpoints/Mixtral-8x22B-v0.1-2d-fsdp-tp https://training.mlcommons-storage.org/metadata/mixtral-8x22b-v0-1-2d-fsdp-tp-checkpoint.uri
 ```
 
 ## Docker Images
 ```
-mkdir -p docker-images
-rclone copy mlc-training:mlcommons-training-wg-public/mixtral_8x22b/docker-images ./docker-images -P
+bash <(curl -s https://raw.githubusercontent.com/mlcommons/r2-downloader/refs/heads/main/mlc-r2-downloader.sh) https://training.mlcommons-storage.org/metadata/mixtral-8x22b-docker-images.uri
 ```

--- a/retired_benchmarks/mixtral8x22b/README.md
+++ b/retired_benchmarks/mixtral8x22b/README.md
@@ -487,21 +487,21 @@ black mixture_of_experts_pretraining/
 # Train and eval datasets
 bash <(curl -s https://raw.githubusercontent.com/mlcommons/r2-downloader/refs/heads/main/mlc-r2-downloader.sh) -d datasets/c4 https://training.mlcommons-storage.org/metadata/c4-train-and-eval-datasets.uri
 ```
-```
+```bash
 # Preprocessed dataset
 bash <(curl -s https://raw.githubusercontent.com/mlcommons/r2-downloader/refs/heads/main/mlc-r2-downloader.sh) -d datasets/preprocessed_c4 https://training.mlcommons-storage.org/metadata/mixtral-8x22b-preprocessed-c4-dataset.uri
 ```
 ## Checkpoints
 * Mixtral-8x22B-v0.1-fsdp: use for `tensor_parallelism=1`
-```
+```bash
 bash <(curl -s https://raw.githubusercontent.com/mlcommons/r2-downloader/refs/heads/main/mlc-r2-downloader.sh) -d checkpoints/Mixtral-8x22B-v0.1-fsdp https://training.mlcommons-storage.org/metadata/mixtral-8x22b-v0-1-fsdp-checkpoint.uri
 ```
 * Mixtral-8x22B-v0.1-2d-fsdp-tp: use for `tensor_parallelism` > 1
-```
+```bash
 bash <(curl -s https://raw.githubusercontent.com/mlcommons/r2-downloader/refs/heads/main/mlc-r2-downloader.sh) -d checkpoints/Mixtral-8x22B-v0.1-2d-fsdp-tp https://training.mlcommons-storage.org/metadata/mixtral-8x22b-v0-1-2d-fsdp-tp-checkpoint.uri
 ```
 
 ## Docker Images
-```
+```bash
 bash <(curl -s https://raw.githubusercontent.com/mlcommons/r2-downloader/refs/heads/main/mlc-r2-downloader.sh) https://training.mlcommons-storage.org/metadata/mixtral-8x22b-docker-images.uri
 ```

--- a/small_llm_pretraining/nemo/README.md
+++ b/small_llm_pretraining/nemo/README.md
@@ -46,7 +46,7 @@ We use [AllenAI C4](https://huggingface.co/datasets/allenai/c4) dataset for this
 export C4_PATH=""
 
 # download the full C4 files, including all raw train and validations
-rclone copy mlc-training:mlcommons-training-wg-public/common/datasets/c4/original/en_json/3.0.1 $C4_PATH -P
+bash <(curl -s https://raw.githubusercontent.com/mlcommons/r2-downloader/refs/heads/main/mlc-r2-downloader.sh) -d $C4_PATH https://training.mlcommons-storage.org/metadata/c4-full-dataset-unzipped.uri
 ```
 After downloading, run the following command to process them to zip them into `.gz` format before running the data preprocessing. 
 

--- a/small_llm_pretraining/nemo/README.md
+++ b/small_llm_pretraining/nemo/README.md
@@ -22,7 +22,7 @@ The current codebase is using the c4/en/3.0.1 dataset from [HuggingFace/AllenAI]
 
 ## Preprocessed data download
 
-The pre-tokenized dataset and the tokenizer are available to download. More instructions to download on Windows are available [here](https://training.mlcommons-storage.org/index.html). You can download using the following commands:
+The pre-tokenized dataset and the tokenizer are available to download. More information about the MLCommons R2 Downloader, including how to run it on Windows, are available [here](https://training.mlcommons-storage.org). You can download using the following commands:
 
 ```bash
 # data 

--- a/small_llm_pretraining/nemo/README.md
+++ b/small_llm_pretraining/nemo/README.md
@@ -29,7 +29,7 @@ The pre-tokenized dataset and the tokenizer are available to download. More info
 # go to the path where you want the data to be downloaded
 # use the same path in config when exporting PREPROCESSED_PATH
 bash <(curl -s https://raw.githubusercontent.com/mlcommons/r2-downloader/refs/heads/main/mlc-r2-downloader.sh) -d llama3_1_8b_preprocessed_c4_dataset https://training.mlcommons-storage.org/metadata/llama-3-1-8b-preprocessed-c4-dataset.uri
-
+```
 ```bash
 # tokenizer 
 # go to the path where you want the tokenizer to be downloaded
@@ -50,7 +50,7 @@ bash <(curl -s https://raw.githubusercontent.com/mlcommons/r2-downloader/refs/he
 ```
 After downloading, run the following command to process them to zip them into `.gz` format before running the data preprocessing. 
 
-```
+```bash
 bash utils/parallel_compress_json_to_gz.sh
 ```
 


### PR DESCRIPTION
While the Mixtral 8x22b benchmark is retired, the tokenizer and the processed C4 dataset are still used for the Llama 3.1 405B benchmark. The Llama 3.1 8B benchmark also uses the C4 resource. As such, many of the the C4 and Mixtral 8x22b resources are in a shared location within the R2 bucket (`/common`). 

This PR follows on the now [merged PR in the r2-infra repo](https://github.com/mlcommons/r2-infra/pull/40) to make these resources available via the MLC R2 Downloader ([repo](https://github.com/mlcommons/r2-downloader)) ([Training download page](https://training.mlcommons-storage.org)).

This PR updates the READMEs for all benchmarks using these resources to fully switch from outing Rclone to the R2 Downloader.